### PR TITLE
Build with Visual Studio 10 Compiler (Windows SDK 7.1)

### DIFF
--- a/src/mspdb.cpp
+++ b/src/mspdb.cpp
@@ -187,7 +187,7 @@ mspdb::PDB* CreatePDB(const wchar_t* pdbname)
 	mspdb::PDB* pdb = 0;
 	long data[194] = { 193, 0 };
 	wchar_t ext[256] = L".exe";
-	if (!(*pPDBOpen2W) (pdbname, "wf", data, ext, 0x400, &pdb))
+	if (!((*pPDBOpen2W) (pdbname, "wf", data, ext, 0x400, &pdb)))
 		return 0;
 
 	return pdb;

--- a/src/mspdb.h
+++ b/src/mspdb.h
@@ -199,8 +199,8 @@ public: virtual void MRECmp::structIsBoring(unsigned long);
 //public: virtual void * Pool<65536>::AllocBytes(unsigned int);
 //public: virtual void EnumSyms::get(unsigned char * *);
 
-typedef int __cdecl fnPDBOpen2W(unsigned short const *path,char const *mode,long *p,
-				unsigned short *ext,unsigned int flags,struct PDB **pPDB);
+typedef int __cdecl fnPDBOpen2W(const wchar_t *path,char const *mode,long *p,
+				wchar_t *ext,unsigned int flags,struct PDB **pPDB);
 
 struct PDB_part1 {
 public: virtual unsigned long QueryInterfaceVersion(void);

--- a/src/readDwarf.cpp
+++ b/src/readDwarf.cpp
@@ -289,7 +289,7 @@ namespace std
 	template<typename T1, typename T2>
 	struct hash<std::pair<T1, T2>>
 	{
-		size_t operator()(const std::pair<T1, T2>& t)
+		size_t operator()(const std::pair<T1, T2>& t) const
 		{
 			return std::hash<T1>()(t.first) ^ std::hash<T2>()(t.second);
 		}

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -1,6 +1,7 @@
 #ifndef __READDWARF_H__
 #define __READDWARF_H__
 
+#include <cstring>
 #include <string>
 #include <vector>
 #include "mspdb.h"


### PR DESCRIPTION
Hello,
I didn't have VCExpress installed, only the compiler that came with the Windows SDK 7.1.  These changes were neded to have it compile. Maybe you want to merge them.

```
rem 
rem Use Windows SDK compiler to build cv2pdb.exe
rem
if not exist out mkdir out
del out\*.obj
cd out
for %%i in (src/cv2pdb.cpp 
	src/demangle.cpp 
	src/dwarf2pdb.cpp 
	src/readDwarf.cpp
	src/main.cpp 
	src/mspdb.cpp 
	src/PEImage.cpp 
	src/symutil.cpp 
	src/cvutil.cpp 
	src/dviewhelper/dviewhelper.cpp) do (
	cl /nologo /c /wd4996 /EHa ..\%%i
)
cd ..
cl /nologo /Fecv2pdb.exe /EHa /MT out\*.obj advapi32.lib dbghelp.lib
```