### PR TITLE
Truncate symbols that are too long

### DIFF
--- a/src/cv2pdb.cpp
+++ b/src/cv2pdb.cpp
@@ -3016,7 +3016,7 @@ bool CV2PDB::addUdtSymbol(int type, const char* name)
 	codeview_symbol* sym = (codeview_symbol*) (udtSymbols + cbUdtSymbols);
 	sym->udt_v1.id = S_UDT_V1;
 	sym->udt_v1.type = translateType(type);
-	strcpy (sym->udt_v1.p_name.name, name ? name : ""); // allow anonymous typedefs
+	cstrcpy_v (true, (BYTE*)sym->udt_v1.p_name.name, name ? name : ""); // allow anonymous typedefs
 	sym->udt_v1.p_name.namelen = strlen(sym->udt_v1.p_name.name);
 	sym->udt_v1.len = sizeof(sym->udt_v1) + sym->udt_v1.p_name.namelen - 1 - 2;
 	cbUdtSymbols += sym->udt_v1.len + 2;

--- a/src/symutil.cpp
+++ b/src/symutil.cpp
@@ -4,6 +4,8 @@
 // License for redistribution is given by the Artistic License 2.0
 // see file LICENSE for further details
 
+#include <algorithm>
+
 #include "symutil.h"
 #include "demangle.h"
 
@@ -266,8 +268,10 @@ int cstrcpy_v(bool v3, BYTE* d, const char* s)
 		assert(len < 256);
 		*d++ = len;
 	}
+	len = (std::min)(len, kMaxNameLen-1);
 
 	memcpy(d, s, len + 1);
+	d[len] = '\0';
 
 	for(int i = 0; i < len; i++)
 		if (d[i] == '.')


### PR DESCRIPTION
This fixes symbols longer than `kMaxNameLen` being copied in their entirety and overwriting other memory instead of being truncated.