### PR TITLE
Various improvements for Ada

### DIFF
--- a/src/cv2pdb.cpp
+++ b/src/cv2pdb.cpp
@@ -1860,8 +1860,8 @@ int CV2PDB::appendModifierType(int type, int attr)
 	dtype->modifier_v2.type = translateType(type);
 	dtype->modifier_v2.attribute = attr;
 	int len = sizeof(dtype->modifier_v2);
-	//for (; len & 3; len++)
-	//	userTypes[cbUserTypes + len] = 0xf4 - (len & 3);
+	for (; len & 3; len++)
+		userTypes[cbUserTypes + len] = 0xf4 - (len & 3);
 	dtype->modifier_v2.len = len - 2;
 	cbUserTypes += len;
 

--- a/src/cv2pdb.cpp
+++ b/src/cv2pdb.cpp
@@ -49,6 +49,7 @@ CV2PDB::CV2PDB(PEImage& image)
 	thisIsNotRef = true;
 	v3 = true;
 	countEntries = img.countCVEntries();
+	build_cfi_index();
 }
 
 CV2PDB::~CV2PDB()

--- a/src/cv2pdb.cpp
+++ b/src/cv2pdb.cpp
@@ -843,16 +843,20 @@ int CV2PDB::addFieldNestedType(codeview_fieldtype* dfieldtype, int type, const c
 
 int CV2PDB::addFieldEnumerate(codeview_fieldtype* dfieldtype, const char* name, int val)
 {
+	int len = 0;
+	BYTE *buffer = (BYTE*)dfieldtype;
+
 	dfieldtype->enumerate_v1.id = v3 ? LF_ENUMERATE_V3 : LF_ENUMERATE_V1;
 	dfieldtype->enumerate_v1.attribute = 0;
-	//assert(val < LF_NUMERIC);
-	dfieldtype->enumerate_v1.value = val;
-	int len = cstrcpy_v(v3, (BYTE*)(&dfieldtype->enumerate_v1 + 1), name);
-	len += sizeof (dfieldtype->enumerate_v1);
+	len += 4;
 
-	unsigned char* p = (unsigned char*) dfieldtype;
+    // Append the enumerator value, and then its name
+	len += write_numeric_leaf(val, buffer + len);
+	len += cstrcpy_v(v3, buffer + len, name);
+
+	// Add padding so that the next record is properly aligned
 	for (; len & 3; len++)
-		p[len] = 0xf4 - (len & 3);
+		buffer[len] = 0xf4 - (len & 3);
 	return len;
 }
 

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -180,6 +180,7 @@ public:
 		int& basetype, int& lowerBound, int& upperBound);
 	void getDWARFSubrangeInfo(DWARF_InfoData& subrangeid, DWARF_CompilationUnit* cu,
 		int& basetype, int& lowerBound, int& upperBound);
+	int getDWARFBasicType(int encoding, int byte_size);
 
 	bool mapTypes();
 	bool createTypes();

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -23,6 +23,7 @@ extern "C" {
 class PEImage;
 struct DWARF_InfoData;
 struct DWARF_CompilationUnit;
+class CFIIndex;
 
 class CV2PDB : public LastError
 {
@@ -182,6 +183,7 @@ public:
 		int& basetype, int& lowerBound, int& upperBound);
 	int getDWARFBasicType(int encoding, int byte_size);
 
+	void build_cfi_index();
 	bool mapTypes();
 	bool createTypes();
 
@@ -189,6 +191,7 @@ public:
 	BYTE* libraries;
 
 	PEImage& img;
+	CFIIndex* cfi_index;
 
 	mspdb::PDB* pdb;
 	mspdb::DBI *dbi;

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -264,6 +264,11 @@ public:
 	// DWARF
 	int codeSegOff;
 	std::unordered_map<byte*, int> mapOffsetToType;
+
+	// Value of the DW_AT_low_pc attribute for the current compilation unit.
+	// Specify the default base address for use in location lists and range
+	// lists.
+	uint32_t currentBaseAddress;
 };
 
 #endif //__CV2PDB_H__

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -7,6 +7,8 @@
 #ifndef __CV2PDB_H__
 #define __CV2PDB_H__
 
+#include <stdint.h>
+
 #include "LastError.h"
 #include "mspdb.h"
 #include "readDwarf.h"

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -173,6 +173,7 @@ public:
 	int  addDWARFStructure(DWARF_InfoData& id, DWARF_CompilationUnit* cu, DIECursor cursor);
 	int  addDWARFArray(DWARF_InfoData& arrayid, DWARF_CompilationUnit* cu, DIECursor cursor);
 	int  addDWARFBasicType(const char*name, int encoding, int byte_size);
+	int  addDWARFEnum(DWARF_InfoData& enumid, DWARF_CompilationUnit* cu, DIECursor cursor);
 	int  getTypeByDWARFPtr(DWARF_CompilationUnit* cu, byte* ptr);
 	int  getDWARFTypeSize(DWARF_CompilationUnit* cu, byte* ptr);
 	void getDWARFArrayBounds(DWARF_InfoData& arrayid, DWARF_CompilationUnit* cu, DIECursor cursor,

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -268,6 +268,10 @@ public:
 	int codeSegOff;
 	std::unordered_map<byte*, int> mapOffsetToType;
 
+	// Default lower bound for the current compilation unit. This depends on
+	// the language of the current unit.
+	unsigned currentDefaultLowerBound;
+
 	// Value of the DW_AT_low_pc attribute for the current compilation unit.
 	// Specify the default base address for use in location lists and range
 	// lists.

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -175,7 +175,10 @@ public:
 	int  addDWARFBasicType(const char*name, int encoding, int byte_size);
 	int  getTypeByDWARFPtr(DWARF_CompilationUnit* cu, byte* ptr);
 	int  getDWARFTypeSize(DWARF_CompilationUnit* cu, byte* ptr);
-	int  getDWARFArrayBounds(DWARF_InfoData& arrayid, DWARF_CompilationUnit* cu, DIECursor cursor, int& upperBound);
+	void getDWARFArrayBounds(DWARF_InfoData& arrayid, DWARF_CompilationUnit* cu, DIECursor cursor,
+		int& basetype, int& lowerBound, int& upperBound);
+	void getDWARFSubrangeInfo(DWARF_InfoData& subrangeid, DWARF_CompilationUnit* cu,
+		int& basetype, int& lowerBound, int& upperBound);
 
 	bool mapTypes();
 	bool createTypes();

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -789,10 +789,21 @@ bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, DWARF_CompilationUnit* cu, DIE
 						// TODO: handle base address selection
 						byte *r = (byte *)img.debug_ranges + id.ranges;
 						byte *rend = (byte *)img.debug_ranges + img.debug_ranges_length;
+						bool is_= img.isX64() ? 8 : 4;
 						while (r < rend)
 						{
-							uint32_t pclo = RD4(r);
-							uint32_t pchi = RD4(r);
+							uint64_t pclo, pchi;
+
+							if (img.isX64())
+							{
+								pclo = RD8(r);
+								pchi = RD8(r);
+							}
+							else
+							{
+								pclo = RD4(r);
+								pchi = RD4(r);
+							}
 							if (pclo == 0 && pchi == 0)
 								break;
 							if (pclo >= pchi)

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -742,7 +742,32 @@ bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, DWARF_CompilationUnit* cu, DIE
 			{
 				if (id.tag == DW_TAG_lexical_block)
 				{
-					if (id.hasChild && id.pchi != id.pclo)
+					// It seems it is not possible to describe blocks with
+					// non-contiguous address ranges in CodeView. Instead,
+					// just create a range that is large enough to cover
+					// all continuous ranges.
+					if (id.hasChild && id.ranges != -1u)
+					{
+						id.pclo = -1u;
+						id.pchi = 0;
+
+						// TODO: handle base address selection
+						byte *r = (byte *)img.debug_ranges + id.ranges;
+						byte *rend = (byte *)img.debug_ranges + img.debug_ranges_length;
+						while (r < rend)
+						{
+							uint32_t pclo = RD4(r);
+							uint32_t pchi = RD4(r);
+							if (pclo == 0 && pchi == 0)
+								break;
+							if (pclo >= pchi)
+								continue;
+							id.pclo = min(id.pclo, pclo + currentBaseAddress);
+							id.pchi = max(id.pchi, pchi + currentBaseAddress);
+						}
+					}
+
+					if (id.hasChild && id.pchi > id.pclo)
 					{
 						appendLexicalBlock(id, pclo + codeSegOff);
 						DIECursor next = cursor;

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -716,7 +716,7 @@ bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, DWARF_CompilationUnit* cu, DIE
 		int off = 8;
 
 		DIECursor prev = cursor;
-		while (cursor.readNext(id, true) && id.tag == DW_TAG_formal_parameter)
+		while (cursor.readNext(id, true))
 		{
 			if (id.tag == DW_TAG_formal_parameter)
 			{

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -727,7 +727,6 @@ bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, DWARF_CompilationUnit* cu, DIE
 						appendStackVar(id.name, getTypeByDWARFPtr(cu, id.type), loc, cfa);
 				}
 			}
-			prev = cursor;
 		}
 		appendEndArg();
 

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -1275,6 +1275,24 @@ bool CV2PDB::createTypes()
 
 			case DW_TAG_compile_unit:
 				currentBaseAddress = id.pclo;
+				switch (id.language)
+				{
+				case DW_LANG_Ada83:
+				case DW_LANG_Cobol74:
+				case DW_LANG_Cobol85:
+				case DW_LANG_Fortran77:
+				case DW_LANG_Fortran90:
+				case DW_LANG_Pascal83:
+				case DW_LANG_Modula2:
+				case DW_LANG_Ada95:
+				case DW_LANG_Fortran95:
+				case DW_LANG_PLI:
+					currentDefaultLowerBound = 1;
+					break;
+
+				default:
+					currentDefaultLowerBound = 0;
+				}
 #if !FULL_CONTRIB
 				if (id.dir && id.name)
 				{

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -1259,10 +1259,11 @@ int CV2PDB::addDWARFEnum(DWARF_InfoData& enumid, DWARF_CompilationUnit* cu, DIEC
 				   ? getTypeByDWARFPtr(cu, enumid.type)
 				   : getDWARFBasicType(enumid.encoding, enumid.byte_size);
 	dtype = (codeview_type*)(userTypes + cbUserTypes);
-	cbUserTypes += addEnum(dtype, count, firstFieldlistType, 0, basetype, enumid.name);
+	const char* name = (enumid.name ? enumid.name : "__noname");
+	cbUserTypes += addEnum(dtype, count, firstFieldlistType, 0, basetype, name);
 	int enumType = nextUserType++;
 
-	addUdtSymbol(enumType, enumid.name);
+	addUdtSymbol(enumType, name);
 	return enumType;
 }
 

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -937,7 +937,7 @@ void CV2PDB::getDWARFSubrangeInfo(DWARF_InfoData& subrangeid, DWARF_CompilationU
 	if (!cu || subrangeid.tag != DW_TAG_subrange_type)
 		return;
 
-	basetype = T_INT4; // TODO: somehow use subrangeid.type
+	basetype = getTypeByDWARFPtr(cu, subrangeid.type);
 	if (subrangeid.has_lower_bound)
 		lowerBound = subrangeid.lower_bound;
 	upperBound = subrangeid.upper_bound;

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -931,14 +931,15 @@ void CV2PDB::getDWARFSubrangeInfo(DWARF_InfoData& subrangeid, DWARF_CompilationU
 	// In case of error, return plausible defaults. Assume the array
 	// contains one item: this is probably helpful to users.
 	basetype = T_INT4;
-	lowerBound = 0;
+	lowerBound = currentDefaultLowerBound;
 	upperBound = lowerBound;
 
 	if (!cu || subrangeid.tag != DW_TAG_subrange_type)
 		return;
 
 	basetype = T_INT4; // TODO: somehow use subrangeid.type
-	lowerBound = subrangeid.lower_bound;
+	if (subrangeid.has_lower_bound)
+		lowerBound = subrangeid.lower_bound;
 	upperBound = subrangeid.upper_bound;
 }
 

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -1229,6 +1229,7 @@ bool CV2PDB::createTypes()
 				break;
 
 			case DW_TAG_compile_unit:
+				currentBaseAddress = id.pclo;
 #if !FULL_CONTRIB
 				if (id.dir && id.name)
 				{

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -1125,7 +1125,7 @@ int CV2PDB::getDWARFTypeSize(DWARF_CompilationUnit* cu, byte* typePtr)
 		{
 			int basetype, upperBound, lowerBound;
 			getDWARFArrayBounds(id, cu, cursor, basetype, lowerBound, upperBound);
-			return (upperBound + lowerBound + 1) * getDWARFTypeSize(cu, id.type);
+			return (upperBound - lowerBound + 1) * getDWARFTypeSize(cu, id.type);
 		}
 		default:
 			if(id.type)

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -1300,12 +1300,12 @@ bool CV2PDB::createTypes()
 			case DW_TAG_array_type:
 				cvtype = addDWARFArray(id, cu, cursor.getSubtreeCursor());
 				break;
-			case DW_TAG_subroutine_type:
 
 			case DW_TAG_enumeration_type:
 				cvtype = addDWARFEnum(id, cu, cursor.getSubtreeCursor());
 				break;
 
+			case DW_TAG_subroutine_type:
 			case DW_TAG_string_type:
 			case DW_TAG_ptr_to_member_type:
 			case DW_TAG_set_type:

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -1238,6 +1238,12 @@ bool CV2PDB::createTypes()
 				cvtype = appendPointerType(getTypeByDWARFPtr(cu, id.type), pointerAttr | 0x20);
 				break;
 
+			case DW_TAG_subrange_type:
+				// It seems we cannot materialize bounds for scalar types in
+				// CodeView, so just redirect to a mere base type.
+				cvtype = appendModifierType(getTypeByDWARFPtr(cu, id.type), 0);
+				break;
+
 			case DW_TAG_class_type:
 			case DW_TAG_structure_type:
 			case DW_TAG_union_type:
@@ -1247,7 +1253,6 @@ bool CV2PDB::createTypes()
 				cvtype = addDWARFArray(id, cu, cursor.getSubtreeCursor());
 				break;
 			case DW_TAG_subroutine_type:
-			case DW_TAG_subrange_type:
 
 			case DW_TAG_enumeration_type:
 			case DW_TAG_string_type:

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -1112,7 +1112,6 @@ int CV2PDB::addDWARFEnum(DWARF_InfoData& enumid, DWARF_CompilationUnit* cu, DIEC
 
 	int fieldlistType = nextDwarfType++;
 	int count = 0;
-	int basetype = T_INT4;
 
 	rdtype = (codeview_reftype*)(dwarfTypes + cbDwarfTypes);
 	int rdbegin = cbDwarfTypes;
@@ -1135,17 +1134,9 @@ int CV2PDB::addDWARFEnum(DWARF_InfoData& enumid, DWARF_CompilationUnit* cu, DIEC
 	rdtype = (codeview_reftype*)(dwarfTypes + rdbegin);
 	rdtype->fieldlist.len += cbDwarfTypes - rdbegin - 2;
 
-	if (enumid.type != 0)
-	{
-		basetype = getTypeByDWARFPtr(cu, enumid.type);
-	}
-	else
-	{
-		// TODO: refactor addDWARFBasicType to reuse the part that creates a
-		// primitive type ID without creating an user type.
-		basetype = T_INT4;
-	}
-
+	int basetype = (enumid.type != 0)
+				   ? getTypeByDWARFPtr(cu, enumid.type)
+				   : getDWARFBasicType(enumid.encoding, enumid.byte_size);
 	dtype = (codeview_type*)(userTypes + cbUserTypes);
 	cbUserTypes += addEnum(dtype, count, fieldlistType, 0, basetype, enumid.name);
 	int enumType = nextUserType++;

--- a/src/readDwarf.cpp
+++ b/src/readDwarf.cpp
@@ -492,8 +492,12 @@ bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
 				break;
 			case DW_AT_lower_bound:
 				assert(a.type == Const || a.type == Ref || a.type == ExprLoc);
-				if (a.type == Const) // TODO: other types not supported yet
+				if (a.type == Const)
+				{
+					// TODO: other types not supported yet
 					id.lower_bound = a.cons;
+					id.has_lower_bound = true;
+				}
 				break;
 			case DW_AT_containing_type: assert(a.type == Ref); id.containing_type = a.ref; break;
 			case DW_AT_specification: assert(a.type == Ref); id.specification = a.ref; break;

--- a/src/readDwarf.cpp
+++ b/src/readDwarf.cpp
@@ -500,6 +500,7 @@ bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
 			case DW_AT_data_member_location: id.member_location = a; break;
 			case DW_AT_location: id.location = a; break;
 			case DW_AT_frame_base: id.frame_base = a; break;
+			case DW_AT_language: assert(a.type == Const); id.language = a.cons; break;
 		}
 	}
 

--- a/src/readDwarf.cpp
+++ b/src/readDwarf.cpp
@@ -505,6 +505,11 @@ bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
 			case DW_AT_location: id.location = a; break;
 			case DW_AT_frame_base: id.frame_base = a; break;
 			case DW_AT_language: assert(a.type == Const); id.language = a.cons; break;
+			case DW_AT_const_value:
+				assert(a.type == Const);
+				id.const_value = a.cons;
+				id.has_const_value = true;
+				break;
 		}
 	}
 

--- a/src/readDwarf.cpp
+++ b/src/readDwarf.cpp
@@ -506,9 +506,22 @@ bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
 			case DW_AT_frame_base: id.frame_base = a; break;
 			case DW_AT_language: assert(a.type == Const); id.language = a.cons; break;
 			case DW_AT_const_value:
-				assert(a.type == Const);
-				id.const_value = a.cons;
-				id.has_const_value = true;
+				switch (a.type)
+				{
+				case Const:
+					id.const_value = a.cons;
+					id.has_const_value = true;
+					break;
+
+				// TODO: handle these
+				case String:
+				case Block:
+					break;
+
+				default:
+					assert(false);
+					break;
+				}
 				break;
 		}
 	}

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -165,6 +165,8 @@ struct DWARF_InfoData
 	long lower_bound;
 	bool has_lower_bound;
 	unsigned language;
+	unsigned long const_value;
+	bool has_const_value;
 
 	void clear()
 	{
@@ -195,6 +197,8 @@ struct DWARF_InfoData
 		lower_bound = 0;
 		has_lower_bound = false;
 		language = 0;
+		const_value = 0;
+		has_const_value = false;
 	}
 
 	void merge(const DWARF_InfoData& id)

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -163,6 +163,7 @@ struct DWARF_InfoData
 	DWARF_Attribute frame_base;
 	long upper_bound;
 	long lower_bound;
+	bool has_lower_bound;
 	unsigned language;
 
 	void clear()
@@ -192,6 +193,7 @@ struct DWARF_InfoData
 		frame_base.type = Invalid;
 		upper_bound = 0;
 		lower_bound = 0;
+		has_lower_bound = false;
 		language = 0;
 	}
 

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -163,6 +163,7 @@ struct DWARF_InfoData
 	DWARF_Attribute frame_base;
 	long upper_bound;
 	long lower_bound;
+	unsigned language;
 
 	void clear()
 	{
@@ -191,6 +192,7 @@ struct DWARF_InfoData
 		frame_base.type = Invalid;
 		upper_bound = 0;
 		lower_bound = 0;
+		language = 0;
 	}
 
 	void merge(const DWARF_InfoData& id)

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -301,14 +301,23 @@ struct DWARF_LineState
 
 	void addLineInfo()
 	{
+		unsigned long addr = address;
+
+		// The DWARF standard says about end_sequence: "indicating that the current
+		// address is that of the first byte after the end of a sequence of target
+		// machine instructions". So if this is a end_sequence row, make it apply
+		// to the last byte of the current sequence.
+		if (end_sequence)
+			addr = last_addr - 1;
+
 #if 0
 		const char* fname = (file == 0 ? file_ptr->file_name : files[file - 1].file_name);
 		printf("Adr:%08x Line: %5d File: %s\n", address, line, fname);
 #endif
-		if (address < seg_offset)
+		if (addr < seg_offset)
 			return;
 		mspdb::LineInfoEntry entry;
-		entry.offset = address - seg_offset;
+		entry.offset = addr - seg_offset;
 		entry.line = line;
 		lineInfo.push_back(entry);
 	}

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -152,7 +152,7 @@ struct DWARF_InfoData
 	unsigned long encoding;
 	unsigned long pclo;
 	unsigned long pchi;
-	unsigned long ranges;
+	unsigned long ranges; // -1u when attribute is not present
 	byte* type;
 	byte* containing_type;
 	byte* specification;
@@ -180,7 +180,7 @@ struct DWARF_InfoData
 		encoding = 0;
 		pclo = 0;
 		pchi = 0;
-		ranges = 0;
+		ranges = -1u;
 		type = 0;
 		containing_type = 0;
 		specification = 0;
@@ -203,6 +203,7 @@ struct DWARF_InfoData
 		if (id.encoding) encoding = id.encoding;
 		if (id.pclo) pclo = id.pclo;
 		if (id.pchi) pchi = id.pchi;
+		if (id.ranges != -1u) ranges = id.ranges;
 		if (id.type) type = id.type;
 		if (id.containing_type) containing_type = id.containing_type;
 		if (id.specification) specification = id.specification;

--- a/src/symutil.cpp
+++ b/src/symutil.cpp
@@ -268,6 +268,10 @@ int pstrcpy_v(bool v3, BYTE* d, const BYTE* s)
 
 int cstrcpy_v(bool v3, BYTE* d, const char* s)
 {
+	// Process absent names as empty ones
+	if (s == NULL)
+		s = "";
+
 	int len = strlen(s);
 	if(!v3)
 	{


### PR DESCRIPTION
Hello,

At @Adacore, we have started to use cv2pdb to translate GCC’s DWARF output for Ada into PDB/CodeView. We found several bugs, which we tried to fix (for instance array size computation with non-zero low bound index), and also several kinds of types for which we could add translation (for instance enumeration types).

Do you think these changes can be merged? For the record, we tested them by hand on several Ada examples, and are currently trying to develop an automated testsuite, probably based on Microsoft’s CDB command-line debugger. However we haven’t checked the effect on D programs.

Thank you in advance for having a look! :-)