### PR TITLE
Access violation fixed. Better aligning of debug section.

### DIFF
--- a/src/PEImage.cpp
+++ b/src/PEImage.cpp
@@ -140,7 +140,13 @@ bool PEImage::replaceDebugSection (const void* data, int datalen, bool initCV)
 	if(dbgDir)
 		debugdir = *dbgDir;
 	else
+	{
 		memset(&debugdir, 0, sizeof(debugdir));
+		debugdir.Type = IMAGE_DEBUG_TYPE_CODEVIEW;
+	}
+	int datalenRaw = datalen;
+	// Growing the data block to the closest 16-byte boundary to make sure the debug directory is aligned.
+	datalen = (datalen + 0xf) & ~0xf;
 	int xdatalen = datalen + sizeof(debugdir);
 
 	// assume there is place for another section because of section alignment
@@ -221,12 +227,8 @@ bool PEImage::replaceDebugSection (const void* data, int datalen, bool initCV)
 	// append debug data chunk to existing file image
 	memcpy(newdata, dump_base, dump_total_len);
 	memset(newdata + dump_total_len, 0, fill);
-	memcpy(newdata + dump_total_len + fill, data, datalen);
+	memcpy(newdata + dump_total_len + fill, data, datalenRaw);
 
-	if(!dbgDir)
-	{
-		debugdir.Type = 2;
-	}
 	dbgDir = (IMAGE_DEBUG_DIRECTORY*) (newdata + dump_total_len + fill + datalen);
 	memcpy(dbgDir, &debugdir, sizeof(debugdir));
 

--- a/src/cv2pdb.cpp
+++ b/src/cv2pdb.cpp
@@ -170,7 +170,7 @@ bool CV2PDB::openPDB(const TCHAR* pdbname, const TCHAR* pdbref)
 	// Growing the RSDS block to the closest 16-byte boundary to align the debug directory.
 	rsdsLen = (rsdsLen + 0xf) & ~0xf;
 	rsds = (OMFSignatureRSDS *) new char[rsdsLen];
-	memset(rsds, 0, rsdslen);
+	memset(rsds, 0, rsdsLen);
 	memcpy (rsds->Signature, "RSDS", 4);
 	pdb->QuerySignature2(&rsds->guid);
 	rsds->age = pdb->QueryAge();

--- a/src/cv2pdb.cpp
+++ b/src/cv2pdb.cpp
@@ -167,10 +167,7 @@ bool CV2PDB::openPDB(const TCHAR* pdbname, const TCHAR* pdbref)
 #endif
 
 	rsdsLen = 24 + strlen(pdbnameA) + 1; // sizeof(OMFSignatureRSDS) without name
-	// Growing the RSDS block to the closest 16-byte boundary to align the debug directory.
-	rsdsLen = (rsdsLen + 0xf) & ~0xf;
 	rsds = (OMFSignatureRSDS *) new char[rsdsLen];
-	memset(rsds, 0, rsdsLen);
 	memcpy (rsds->Signature, "RSDS", 4);
 	pdb->QuerySignature2(&rsds->guid);
 	rsds->age = pdb->QueryAge();

--- a/src/cv2pdb.cpp
+++ b/src/cv2pdb.cpp
@@ -167,10 +167,10 @@ bool CV2PDB::openPDB(const TCHAR* pdbname, const TCHAR* pdbref)
 #endif
 
 	rsdsLen = 24 + strlen(pdbnameA) + 1; // sizeof(OMFSignatureRSDS) without name
-	// Growing the RSDS block to the closest 16-byte boundary.
-	if (rsdsLen & 0xF)
-		rsdsLen = (rsdsLen | 0xF) + 1;
+	// Growing the RSDS block to the closest 16-byte boundary to align the debug directory.
+	rsdsLen = (rsdsLen + 0xf) & ~0xf;
 	rsds = (OMFSignatureRSDS *) new char[rsdsLen];
+	memset(rsds, 0, rsdslen);
 	memcpy (rsds->Signature, "RSDS", 4);
 	pdb->QuerySignature2(&rsds->guid);
 	rsds->age = pdb->QueryAge();

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -205,6 +205,7 @@ public:
 	int countEntries;
 
 	OMFSignatureRSDS* rsds;
+	int rsdsLen;
 
 	OMFSegMap* segMap;
 	OMFSegMapDesc* segMapDesc;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,7 +63,7 @@ void makefullpath(TCHAR* pdbname)
 	{
 		if (pdbname[2] == '\\' || pdbname[2] == '/')
 			return;
-		drive = T_toupper (pdbname[0]);
+		drive = T_toupper (pdbname[0]) - 'A' + 1;
 		pdbname += 2;
 	}
 	else


### PR DESCRIPTION
1. If exe-file parameter consisted of just a disk letter and a file name (i.e. c:file.exe), AV occurred.
2. Aligning the debug section offset to the closest 16-byte boundary.