### PR TITLE
Label more functions

### DIFF
--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -894,6 +894,8 @@ int CV2PDB::addDWARFFields(DWARF_InfoData& structid, DWARF_CompilationUnit* cu, 
 					DWARF_InfoData memberid;
 					if (membercursor.readNext(memberid))
 					{
+						if (memberid.abstract_origin)
+							mergeAbstractOrigin(memberid, cu);
 						if (memberid.specification)
 							mergeSpecification(memberid, cu);
 
@@ -1416,6 +1418,8 @@ bool CV2PDB::createTypes()
 			//printf("0x%08x, level = %d, id.code = %d, id.tag = %d\n",
 			//    (unsigned char*)cu + id.entryOff - (unsigned char*)img.debug_info, cursor.level, id.code, id.tag);
 
+			if (id.abstract_origin)
+				mergeAbstractOrigin(id, cu);
 			if (id.specification)
 				mergeSpecification(id, cu);
 
@@ -1478,46 +1482,49 @@ bool CV2PDB::createTypes()
 			case DW_TAG_subprogram:
 				if (id.name)
 				{
-					unsigned long entry_point = 0;
-					if (id.pcentry)
+					if (!id.is_artificial)
 					{
-						entry_point = id.pcentry;
-					}
-					else if (id.pclo)
-					{
-						entry_point = id.pclo;
-					}
-					else if (id.ranges != ~0)
-					{
-						entry_point = ~0;
-						byte* r = (byte*)img.debug_ranges + id.ranges;
-						byte* rend = (byte*)img.debug_ranges + img.debug_ranges_length;
-						while (r < rend)
+						unsigned long entry_point = 0;
+						if (id.pcentry)
 						{
-							uint64_t pclo, pchi;
-
-							if (img.isX64())
-							{
-								pclo = RD8(r);
-								pchi = RD8(r);
-							}
-							else
-							{
-								pclo = RD4(r);
-								pchi = RD4(r);
-							}
-							if (pclo == 0 && pchi == 0)
-								break;
-							if (pclo >= pchi)
-								continue;
-							entry_point = min(entry_point, pclo + currentBaseAddress);
+							entry_point = id.pcentry;
 						}
-						if (entry_point == ~0)
-							entry_point = 0;
-					}
+						else if (id.pclo)
+						{
+							entry_point = id.pclo;
+						}
+						else if (id.ranges != ~0)
+						{
+							entry_point = ~0;
+							byte* r = (byte*)img.debug_ranges + id.ranges;
+							byte* rend = (byte*)img.debug_ranges + img.debug_ranges_length;
+							while (r < rend)
+							{
+								uint64_t pclo, pchi;
 
-					if (entry_point)
-						mod->AddPublic2(id.name, img.codeSegment + 1, entry_point - codeSegOff, 0);
+								if (img.isX64())
+								{
+									pclo = RD8(r);
+									pchi = RD8(r);
+								}
+								else
+								{
+									pclo = RD4(r);
+									pchi = RD4(r);
+								}
+								if (pclo == 0 && pchi == 0)
+									break;
+								if (pclo >= pchi)
+									continue;
+								entry_point = min(entry_point, pclo + currentBaseAddress);
+							}
+							if (entry_point == ~0)
+								entry_point = 0;
+						}
+
+						if (entry_point)
+							mod->AddPublic2(id.name, img.codeSegment + 1, entry_point - codeSegOff, 0);
+					}
 
 					if (id.pclo && id.pchi)
 						addDWARFProc(id, cu, cursor.getSubtreeCursor());

--- a/src/readDwarf.cpp
+++ b/src/readDwarf.cpp
@@ -486,6 +486,14 @@ bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
 				else
 					assert(false);
 			    break;
+		    case DW_AT_entry_pc:
+			    if (a.type == Addr)
+				    id.pcentry = a.addr;
+			    else if (a.type == Const)
+				    id.pcentry = id.pclo + a.cons;
+			    else
+				    assert(false);
+			    break;
 			case DW_AT_ranges:
 				if (a.type == SecOffset)
 					id.ranges = a.sec_offset;

--- a/src/readDwarf.cpp
+++ b/src/readDwarf.cpp
@@ -562,7 +562,11 @@ bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
 					break;
 				}
 				break;
-		    case DW_AT_artificial: assert(a.type == Flag); id.is_artificial = true; break;
+		    case DW_AT_artificial:
+				assert(a.type == Flag);
+				id.has_artificial = true;
+				id.is_artificial = true;
+				break;
 		}
 	}
 

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -157,6 +157,7 @@ struct DWARF_InfoData
 	byte* type;
 	byte* containing_type;
 	byte* specification;
+	byte* abstract_origin;
 	unsigned long inlined;
 	bool external;
 	DWARF_Attribute location;
@@ -168,6 +169,7 @@ struct DWARF_InfoData
 	unsigned language;
 	unsigned long const_value;
 	bool has_const_value;
+	bool is_artificial;
 
 	void clear()
 	{
@@ -190,6 +192,7 @@ struct DWARF_InfoData
 		type = 0;
 		containing_type = 0;
 		specification = 0;
+		abstract_origin = 0;
 		inlined = 0;
 		external = 0;
 		member_location.type = Invalid;
@@ -201,31 +204,33 @@ struct DWARF_InfoData
 		language = 0;
 		const_value = 0;
 		has_const_value = false;
+		is_artificial = false;
 	}
 
 	void merge(const DWARF_InfoData& id)
 	{
-		if (id.name) name = id.name;
-		if (id.linkage_name) linkage_name = id.linkage_name;
-		if (id.dir) dir = id.dir;
-		if (id.byte_size) byte_size = id.byte_size;
-		if (id.sibling) sibling = id.sibling;
-		if (id.encoding) encoding = id.encoding;
-		if (id.pclo) pclo = id.pclo;
-		if (id.pchi) pchi = id.pchi;
-		if (id.ranges != ~0) ranges = id.ranges;
-		if (id.pcentry)
-			pcentry = id.pcentry;
-		if (id.type) type = id.type;
-		if (id.containing_type) containing_type = id.containing_type;
-		if (id.specification) specification = id.specification;
-		if (id.inlined) inlined = id.inlined;
-		if (id.external) external = id.external;
-		if (id.member_location.type != Invalid) member_location = id.member_location;
-		if (id.location.type != Invalid) location = id.location;
-		if (id.frame_base.type != Invalid) frame_base = id.frame_base;
-		if (id.upper_bound) upper_bound = id.upper_bound;
-		if (id.lower_bound) lower_bound = id.lower_bound;
+		if (!name) name = id.name;
+		if (!linkage_name) linkage_name = id.linkage_name;
+		if (!dir) dir = id.dir;
+		if (!byte_size) byte_size = id.byte_size;
+		if (!sibling) sibling = id.sibling;
+		if (!encoding) encoding = id.encoding;
+		if (!pclo) pclo = id.pclo;
+		if (!pchi) pchi = id.pchi;
+		if (ranges == ~0) ranges = id.ranges;
+		if (!pcentry) pcentry = id.pcentry;
+		if (!type) type = id.type;
+		if (!containing_type) containing_type = id.containing_type;
+		if (!specification) specification = id.specification;
+		if (!abstract_origin) abstract_origin = id.abstract_origin;
+		if (!inlined) inlined = id.inlined;
+		if (!external) external = id.external;
+		if (member_location.type == Invalid) member_location = id.member_location;
+		if (location.type == Invalid) location = id.location;
+		if (frame_base.type == Invalid) frame_base = id.frame_base;
+		if (!upper_bound) upper_bound = id.upper_bound;
+		if (!lower_bound) lower_bound = id.lower_bound;
+		if (!is_artificial) is_artificial = id.is_artificial;
 	}
 };
 
@@ -363,6 +368,7 @@ class PEImage;
 // as either an absolute value, a register, or a register-relative address.
 Location decodeLocation(const PEImage& img, const DWARF_Attribute& attr, const Location* frameBase = 0, int at = 0);
 
+void mergeAbstractOrigin(DWARF_InfoData& id, DWARF_CompilationUnit* cu);
 void mergeSpecification(DWARF_InfoData& id, DWARF_CompilationUnit* cu);
 
 // Debug Information Entry Cursor

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -170,6 +170,7 @@ struct DWARF_InfoData
 	unsigned long const_value;
 	bool has_const_value;
 	bool is_artificial;
+	bool has_artificial;
 
 	void clear()
 	{
@@ -205,6 +206,7 @@ struct DWARF_InfoData
 		const_value = 0;
 		has_const_value = false;
 		is_artificial = false;
+		has_artificial = false;
 	}
 
 	void merge(const DWARF_InfoData& id)
@@ -229,8 +231,9 @@ struct DWARF_InfoData
 		if (location.type == Invalid) location = id.location;
 		if (frame_base.type == Invalid) frame_base = id.frame_base;
 		if (!upper_bound) upper_bound = id.upper_bound;
-		if (!lower_bound) lower_bound = id.lower_bound;
-		if (!is_artificial) is_artificial = id.is_artificial;
+		if (!has_lower_bound) { lower_bound = id.lower_bound; has_lower_bound = id.has_lower_bound; }
+		if (!has_const_value) { const_value = id.const_value; has_const_value = id.has_const_value; }
+		if (!has_artificial) { is_artificial = id.is_artificial; has_artificial = id.has_artificial; }
 	}
 };
 

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -153,6 +153,7 @@ struct DWARF_InfoData
 	unsigned long pclo;
 	unsigned long pchi;
 	unsigned long ranges; // -1u when attribute is not present
+	unsigned long pcentry;
 	byte* type;
 	byte* containing_type;
 	byte* specification;
@@ -185,6 +186,7 @@ struct DWARF_InfoData
 		pclo = 0;
 		pchi = 0;
 		ranges = ~0;
+		pcentry = 0;
 		type = 0;
 		containing_type = 0;
 		specification = 0;
@@ -212,6 +214,8 @@ struct DWARF_InfoData
 		if (id.pclo) pclo = id.pclo;
 		if (id.pchi) pchi = id.pchi;
 		if (id.ranges != ~0) ranges = id.ranges;
+		if (id.pcentry)
+			pcentry = id.pcentry;
 		if (id.type) type = id.type;
 		if (id.containing_type) containing_type = id.containing_type;
 		if (id.specification) specification = id.specification;


### PR DESCRIPTION
The DWARF spec says that a function's entry instruction is either marked by `DW_AT_entry_pc` or is the lowest address in the function.  GCC likes to split up functions, so the old method of just checking for `DW_AT_low_pc` and `DW_AT_high_pc` wasn't finding all of them.  This patch checks `DW_AT_entry_pc` for an explicit entry point, and falls back to iterating through the function ranges if it's missing.  GCC also likes to separate a function's name and address range into different DIEs linked by `DW_AT_abstract_origin`, so we check that in addition to `DW_AT_specification` to match even more functions.