### PR TITLE
Add more line number information

### DIFF
--- a/src/dwarflines.cpp
+++ b/src/dwarflines.cpp
@@ -5,8 +5,6 @@
 // see file LICENSE for further details
 //
 
-#include <algorithm>
-
 #include "PEImage.h"
 #include "mspdb.h"
 #include "dwarf.h"

--- a/src/dwarflines.cpp
+++ b/src/dwarflines.cpp
@@ -102,7 +102,7 @@ bool _flushDWARFLines(const PEImage& img, mspdb::Mod* mod, DWARF_LineState& stat
 		printf("  %08x: %4d\n", state.lineInfo[ln].offset + 0x401000, state.lineInfo[ln].line);
 #endif
 
-	std::sort(begin(state.lineInfo), end(state.lineInfo), [](const auto &s1, const auto &s2) {
+	std::sort(begin(state.lineInfo), end(state.lineInfo), [](const mspdb::LineInfoEntry& s1, const mspdb::LineInfoEntry& s2) {
 		return s1.offset < s2.offset || s1.offset == s2.offset && s1.line < s2.line;
 	});
 	

--- a/src/dwarflines.cpp
+++ b/src/dwarflines.cpp
@@ -245,12 +245,7 @@ bool interpretDWARFLines(const PEImage& img, mspdb::Mod* mod)
 						if (!mod && state.section == -1)
 							state.section = img.getRelocationInLineSegment((char*)p - img.debug_line);
 						unsigned long adr = ptrsize == 8 ? RD8(p) : RD4(p);
-						if(adr)
-							state.address = adr;
-						else if (!mod)
-							state.address = adr;
-						else
-							state.address = state.last_addr; // strange adr 0 for templates?
+						state.address = adr;
 						state.op_index = 0;
 						break;
 					}

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -280,12 +280,14 @@ struct DWARF_LineState
 	unsigned long section;
 	unsigned long last_addr;
 	std::vector<mspdb::LineInfoEntry> lineInfo;
+	unsigned int lineInfo_file;
 
 	DWARF_LineState()
 	{
 		file_ptr = nullptr;
 		seg_offset = 0x400000;
 		last_addr = 0;
+		lineInfo_file = 0;
 
 		init(0);
 	}
@@ -312,29 +314,6 @@ struct DWARF_LineState
 		int address_advance = hdr->minimum_instruction_length * ((op_index + operation_advance) / maximum_operations_per_instruction);
 		address += address_advance;
 		op_index = (op_index + operation_advance) % maximum_operations_per_instruction;
-	}
-
-	void addLineInfo()
-	{
-		unsigned long addr = address;
-
-		// The DWARF standard says about end_sequence: "indicating that the current
-		// address is that of the first byte after the end of a sequence of target
-		// machine instructions". So if this is a end_sequence row, make it apply
-		// to the last byte of the current sequence.
-		if (end_sequence)
-			addr = last_addr - 1;
-
-#if 0
-		const char* fname = (file == 0 ? file_ptr->file_name : files[file - 1].file_name);
-		printf("Adr:%08x Line: %5d File: %s\n", address, line, fname);
-#endif
-		if (addr < seg_offset)
-			return;
-		mspdb::LineInfoEntry entry;
-		entry.offset = addr - seg_offset;
-		entry.line = line;
-		lineInfo.push_back(entry);
 	}
 };
 


### PR DESCRIPTION
The previous line number code flushed immediately when the filename changed.  This meant that some instructions after the current row's address could be not marked because they hadn't been passed when the flush happened but were before the address in the row for the new file.  This patch changes `addLineInfo` to flush when adding a row that indicates a file change.  Since at that point we know the address of the first instruction from the new file we can mark any previous instructions as being part of the previous file.

This also removes the special-casing of address 0; it's not mentioned in the DWARF spec and causes issues due to a linker bug: https://sourceware.org/bugzilla/show_bug.cgi?id=24192