### PR TITLE
introduce a symbol cache

### DIFF
--- a/src/PEImage.h
+++ b/src/PEImage.h
@@ -10,9 +10,17 @@
 #include "LastError.h"
 
 #include <windows.h>
+#include <unordered_map>
 
 struct OMFDirHeader;
 struct OMFDirEntry;
+
+struct SymbolInfo
+{
+	int seg;
+	unsigned long off;
+	bool dllimport;
+};
 
 #define IMGHDR(x) (hdr32 ? hdr32->x : hdr64->x)
 
@@ -93,6 +101,7 @@ public:
 
     int dumpDebugLineInfoCOFF();
     int dumpDebugLineInfoOMF();
+	void createSymbolCache();
 
 private:
 	bool _initFromCVDebugDir(IMAGE_DEBUG_DIRECTORY* ddir);
@@ -118,6 +127,7 @@ private:
 	bool x64;     // targets 64-bit machine
 	bool bigobj;
 	bool dbgfile; // is DBG file
+	std::unordered_map<std::string, SymbolInfo> symbolCache;
 
 public:
 	//dwarf

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -1402,6 +1402,7 @@ bool CV2PDB::mapTypes()
 
 bool CV2PDB::createTypes()
 {
+	img.createSymbolCache();
 	mspdb::Mod* mod = globalMod();
 	int typeID = nextUserType;
 	int pointerAttr = img.isX64() ? 0x1000C : 0x800A;


### PR DESCRIPTION
I used `cv2pdb` with `dxvk` and it was extremely slow. I introduced a symbol cache which drastically reduces the run time.

Benchmark results:

  | size in MB | old | new | ratio
-- | -- | -- | -- | --
d3d11 | 185 | 52,4 | 6,5 | 8,1
dxgi | 74 | 20,4 | 3 | 6,8
