### PR TITLE
Allow the mspdb DLL to be found via vswhere.exe

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,4 @@
-name: build cv2pdb
+name: build and test cv2pdb
 
 on: [push, pull_request]
 
@@ -26,3 +26,30 @@ jobs:
         with:
           name: bin
           path: bin
+  test-with-g4w-sdk:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - name: Download bin/
+        uses: actions/download-artifact@v2
+        with:
+          name: bin
+          path: bin
+      - uses: git-for-windows/setup-git-for-windows-sdk@v1
+      - name: verify using Git for Windows' GCC
+        shell: bash
+        run: |
+          set -x &&
+          cat >hello.c <<-\EOF &&
+          #include <stdio.h>
+
+          int main(int argc, char **argv)
+          {
+            printf("Hello, world\n");
+            return 0;
+          }
+          EOF
+
+          gcc -g -o hello.exe hello.c &&
+          bin/${{env.BUILD_CONFIGURATION}}*/cv2pdb.exe hello.exe world.exe &&
+          ls -l hello* world*

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,28 @@
+name: build cv2pdb
+
+on: [push, pull_request]
+
+env:
+  # Path to the solution file relative to the root of the project.
+  SOLUTION_FILE_PATH: src/cv2pdb.vcxproj
+
+  # Configuration type to build.
+  BUILD_CONFIGURATION: Release
+  BUILD_PLATFORM: x64
+  BUILD_PLATFORM_TOOLSET: v142
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.2
+      - name: Build
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+        run: msbuild /m /p:PlatformToolset=${{env.BUILD_PLATFORM_TOOLSET}} /p:Platform=${{env.BUILD_PLATFORM}} /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+      - name: Upload bin/
+        uses: actions/upload-artifact@v2
+        with:
+          name: bin
+          path: bin


### PR DESCRIPTION
The incredibly useful `vswhere.exe` tool can be used to abstract away all the nitty-gritty details of figuring out where Visual Studio is installed.

This patch adds support for making use of that tool. If the tool is found and finds a Visual Studio, we use the corresponding path. Otherwise, we simply continue as we would have continued before this patch.

We are already using this patch in Git for Windows for quite some time, with a lot of success.