### PR TITLE
Add rudimentary support for DWARF5

### DIFF
--- a/src/PEImage.cpp
+++ b/src/PEImage.cpp
@@ -492,6 +492,8 @@ void PEImage::initDWARFSegments()
 			debug_abbrev = DPV<char>(sec[s].PointerToRawData, debug_abbrev_length = sizeInImage(sec[s]));
 		if(strcmp(name, ".debug_line") == 0)
 			debug_line = DPV<char>(sec[linesSegment = s].PointerToRawData, debug_line_length = sizeInImage(sec[s]));
+		if (strcmp(name, ".debug_line_str") == 0)
+			debug_line_str = DPV<char>(sec[s].PointerToRawData, debug_line_str_length = sizeInImage(sec[s]));
 		if(strcmp(name, ".debug_frame") == 0)
 			debug_frame = DPV<char>(sec[s].PointerToRawData, debug_frame_length = sizeInImage(sec[s]));
 		if(strcmp(name, ".debug_str") == 0)

--- a/src/PEImage.h
+++ b/src/PEImage.h
@@ -137,6 +137,7 @@ public:
 	char* debug_info;     unsigned long debug_info_length;
 	char* debug_abbrev;   unsigned long debug_abbrev_length;
 	char* debug_line;     unsigned long debug_line_length;
+	char* debug_line_str; unsigned long debug_line_str_length;
 	char* debug_frame;    unsigned long debug_frame_length;
 	char* debug_str;
 	char* debug_loc;      unsigned long debug_loc_length;

--- a/src/dwarf.h
+++ b/src/dwarf.h
@@ -196,6 +196,12 @@ extern "C" {
 #define DW_children_yes                 1
 
 
+#define DW_LNCT_path 1
+#define DW_LNCT_directory_index 2
+#define DW_LNCT_timestamp 3
+#define DW_LNCT_size 4
+#define DW_LNCT_MD5 5
+
 
 #define DW_FORM_addr                    0x01
 #define DW_FORM_block2                  0x03
@@ -221,7 +227,11 @@ extern "C" {
 #define DW_FORM_sec_offset              0x17 /* DWARF4 */
 #define DW_FORM_exprloc                 0x18 /* DWARF4 */
 #define DW_FORM_flag_present            0x19 /* DWARF4 */
-/* 0x1a thru 0x1f were left unused accidentally. Reserved for future use. */
+#define DW_FORM_strx                    0x1a /* DWARF5 */
+#define DW_FORM_addrx                   0x1b /* DWARF5 */
+#define DW_FORM_strp_sup                0x1d /* DWARF5 */
+#define DW_FORM_data16                  0x1e /* DWARF5 */
+#define DW_FORM_line_strp               0x1f /* DWARF5 */
 #define DW_FORM_ref_sig8                0x20 /* DWARF4 */
 
 #define DW_AT_sibling                           0x01

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -239,7 +239,30 @@ struct DWARF_InfoData
 
 static const int maximum_operations_per_instruction = 1;
 
+struct DWARF_TypeForm
+{
+	unsigned int type, form;
+};
+
 struct DWARF_LineNumberProgramHeader
+{
+	unsigned int unit_length; // 12 byte in DWARF-64
+	unsigned short version;
+	byte address_size; // new in DWARF5
+	byte segment_selector_size; // new in DWARF5
+	unsigned int header_length; // 8 byte in DWARF-64
+	byte minimum_instruction_length;
+	byte maximum_operations_per_instruction; // not in DWARF 2/3
+	byte default_is_stmt;
+	signed char line_base;
+	byte line_range;
+	byte opcode_base;
+	//LEB128 standard_opcode_lengths[opcode_base];
+	// string include_directories[] // zero byte terminated
+	// DWARF_FileNames file_names[] // zero byte terminated
+};
+
+struct DWARF4_LineNumberProgramHeader
 {
 	unsigned int unit_length; // 12 byte in DWARF-64
 	unsigned short version;


### PR DESCRIPTION
This allows `cv2pdb` to process executables produced by the mingw-w64 version of GCC v11.x. The symptoms of the fixed issue would look like this:

	error: cannot add line number info to module

We will most likely have to run with this patch to allow building Git for Windows henceforth, as we use the mingw-w64 version of GCC provided by the MSYS2 project, and they recently upgraded to GCC v11.x (where it seems impossible to force an older DWARF version via `-gdwarf-<version> -gstrict-dwarf`).

This fixes https://github.com/git-for-windows/git/issues/3488.