### PR TITLE
Refactor PE image section handling. Add debug logging.

### DIFF
--- a/src/cv2pdb.cpp
+++ b/src/cv2pdb.cpp
@@ -17,7 +17,7 @@
 
 static const int typePrefix = 4;
 
-CV2PDB::CV2PDB(PEImage& image)
+CV2PDB::CV2PDB(PEImage& image, DebugLevel debug_)
 : img(image), pdb(0), dbi(0), tpi(0), ipi(0), libraries(0), rsds(0), rsdsLen(0), modules(0), globmod(0)
 , segMap(0), segMapDesc(0), segFrame2Index(0), globalTypeHeader(0)
 , globalTypes(0), cbGlobalTypes(0), allocGlobalTypes(0)
@@ -28,7 +28,7 @@ CV2PDB::CV2PDB(PEImage& image)
 , srcLineStart(0), srcLineSections(0)
 , pointerTypes(0)
 , Dversion(2)
-, debug(false)
+, debug(debug_)
 , classEnumType(0), ifaceEnumType(0), cppIfaceEnumType(0), structEnumType(0)
 , classBaseType(0), ifaceBaseType(0), cppIfaceBaseType(0), structBaseType(0)
 , emptyFieldListType(0)
@@ -149,7 +149,7 @@ bool CV2PDB::openPDB(const TCHAR* pdbname, const TCHAR* pdbref)
 
 	if (!initMsPdb ())
 		return setError("cannot load PDB helper DLL");
-	if (debug)
+	if (debug & DbgBasic)
 	{
 		extern HMODULE modMsPdb;
 		char modpath[260];
@@ -737,6 +737,9 @@ int CV2PDB::countNestedTypes(const codeview_reftype* fieldlist, int type)
 int CV2PDB::addAggregate(codeview_type* dtype, bool clss, int n_element, int fieldlist, int property,
                          int derived, int vshape, int structlen, const char* name, const char* uniquename)
 {
+	if (debug & DbgPdbTypes)
+		fprintf(stderr, "%s%d: adding aggregate %s -> fieldlist:%d\n", __FUNCTION__, __LINE__, name, fieldlist);
+
 	dtype->struct_v2.id = clss ? (v3 ? LF_CLASS_V3 : LF_CLASS_V2) : (v3 ? LF_STRUCTURE_V3 : LF_STRUCTURE_V2);
 	dtype->struct_v2.n_element = n_element;
 	dtype->struct_v2.fieldlist = fieldlist;
@@ -771,6 +774,9 @@ int CV2PDB::addStruct(codeview_type* dtype, int n_element, int fieldlist, int pr
 int CV2PDB::addEnum(codeview_type* dtype, int count, int fieldlist, int property,
                     int type, const char*name)
 {
+	if (debug & DbgPdbTypes)
+		fprintf(stderr, "%s%d: adding enum %s -> fieldlist:%d\n", __FUNCTION__, __LINE__, name, fieldlist);
+
 	dtype->enumeration_v2.id = (v3 ? LF_ENUM_V3 : LF_ENUM_V2);
 	dtype->enumeration_v2.count = count;
 	dtype->enumeration_v2.fieldlist = fieldlist;
@@ -2074,6 +2080,9 @@ int CV2PDB::appendTypedef(int type, const char* name, bool saveTranslation)
 	if(type == 0x78)
 		basetype = 0x75; // dchar type not understood by debugger, use uint instead
 
+	if (debug & DbgPdbTypes)
+		fprintf(stderr, "%s%d: adding typedef %s -> %d\n", __FUNCTION__, __LINE__, name, type);
+
 	int typedefType;
 	if(useTypedefEnum)
 	{
@@ -2981,6 +2990,9 @@ bool CV2PDB::addPublics()
 					char symname[kMaxNameLen];
 					dsym2c((BYTE*)sym->data_v1.p_name.name, sym->data_v1.p_name.namelen, symname, sizeof(symname));
 					int type = translateType(sym->data_v1.symtype);
+					if (debug & DbgPdbSyms)
+						fprintf(stderr, "%s:%d: AddPublic2 %s\n", __FUNCTION__, __LINE__, (const char *)symname);
+
 					if (mod)
 						rc = mod->AddPublic2(symname, sym->data_v1.segment, sym->data_v1.offset, type);
 					else
@@ -2997,6 +3009,8 @@ bool CV2PDB::addPublics()
 
 bool CV2PDB::initGlobalSymbols()
 {
+	if (debug & DbgBasic)
+		fprintf(stderr, "%s:%d, countEntries: %d\n", __FUNCTION__, __LINE__, (int)countEntries);
 	for (int m = 0; m < countEntries; m++)
 	{
 		OMFDirEntry* entry = img.getCVEntry(m);

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -30,7 +30,7 @@ class CFIIndex;
 class CV2PDB : public LastError
 {
 public:
-	CV2PDB(PEImage& image);
+	CV2PDB(PEImage& image, DebugLevel debug);
 	~CV2PDB();
 
 	bool cleanup(bool commit);
@@ -265,7 +265,7 @@ public:
 	bool useGlobalMod;
 	bool thisIsNotRef;
 	bool v3;
-	bool debug;
+	DebugLevel debug;
 	const char* lastError;
 
 	int srcLineSections;

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -230,8 +230,8 @@ class CFICursor
 {
 public:
 	CFICursor(const PEImage& img)
-	: beg((byte*)img.debug_frame)
-	, end((byte*)img.debug_frame + img.debug_frame_length)
+	: beg((byte*)img.debug_frame.base)
+	, end((byte*)img.debug_frame.base + img.debug_frame.length)
 	, ptr(beg)
 	{
 		default_address_size = img.isX64() ? 8 : 4;
@@ -489,7 +489,7 @@ Location findBestCFA(const PEImage& img, const CFIIndex* index, unsigned int pcl
 {
 	bool x64 = img.isX64();
 	Location ebp = { Location::RegRel, x64 ? 6 : 5, x64 ? 16 : 8 };
-	if (!img.debug_frame)
+	if (!img.debug_frame.isPresent())
 		return ebp;
 
 	byte *fde_ptr = index->lookup(pclo, pchi);
@@ -529,8 +529,8 @@ class LOCCursor
 public:
 	LOCCursor(const PEImage& image, unsigned long off)
 	: img (image)
-	, end((byte*)img.debug_loc + img.debug_loc_length)
-	, ptr((byte*)img.debug_loc + off)
+	, end((byte*)img.debug_loc.base + img.debug_loc.length)
+	, ptr((byte*)img.debug_loc.base + off)
 	{
 		default_address_size = img.isX64() ? 8 : 4;
 	}
@@ -701,6 +701,9 @@ bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, DWARF_CompilationUnit* cu, DIE
 
 	checkUdtSymbolAlloc(100 + kMaxNameLen);
 
+	if (debug & DbgPdbSyms)
+		fprintf(stderr, "%s:%d: Adding a proc: %s at %x\n", __FUNCTION__, __LINE__, procid.name, pclo);
+
 	// GLOBALPROC
 	codeview_symbol*cvs = (codeview_symbol*) (udtSymbols + cbUdtSymbols);
 	cvs->proc_v2.id = v3 ? S_GPROC_V3 : S_GPROC_V2;
@@ -793,8 +796,8 @@ bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, DWARF_CompilationUnit* cu, DIE
 						id.pchi = 0;
 
 						// TODO: handle base address selection
-						byte *r = (byte *)img.debug_ranges + id.ranges;
-						byte *rend = (byte *)img.debug_ranges + img.debug_ranges_length;
+						byte *r = (byte *)img.debug_ranges.base + id.ranges;
+						byte *rend = (byte *)img.debug_ranges.base + img.debug_ranges.length;
 						while (r < rend)
 						{
 							uint64_t pclo, pchi;
@@ -1122,7 +1125,7 @@ bool CV2PDB::addDWARFTypes()
 	checkUdtSymbolAlloc(100);
 
 	int prefix = 4;
-	DWORD* ddata = new DWORD [img.debug_info_length/4]; // large enough
+	DWORD* ddata = new DWORD [img.debug_info.length/4]; // large enough
 	unsigned char *data = (unsigned char*) (ddata + prefix);
 	unsigned int off = 0;
 	unsigned int len;
@@ -1350,9 +1353,9 @@ bool CV2PDB::mapTypes()
 {
 	int typeID = nextUserType;
 	unsigned long off = 0;
-	while (off < img.debug_info_length)
+	while (off < img.debug_info.length)
 	{
-		DWARF_CompilationUnit* cu = (DWARF_CompilationUnit*)(img.debug_info + off);
+		DWARF_CompilationUnit* cu = (DWARF_CompilationUnit*)(img.debug_info.base + off);
 
 		DIECursor cursor(cu, (byte*)cu + sizeof(DWARF_CompilationUnit));
 		DWARF_InfoData id;
@@ -1396,6 +1399,9 @@ bool CV2PDB::mapTypes()
 		off += sizeof(cu->unit_length) + cu->unit_length;
 	}
 
+	if (debug & DbgBasic)
+		fprintf(stderr, "%s:%d: mapped %zd types\n", __FUNCTION__, __LINE__, mapOffsetToType.size());
+
 	nextDwarfType = typeID;
 	return true;
 }
@@ -1407,17 +1413,21 @@ bool CV2PDB::createTypes()
 	int typeID = nextUserType;
 	int pointerAttr = img.isX64() ? 0x1000C : 0x800A;
 
+	if (debug & DbgBasic)
+		fprintf(stderr, "%s:%d: createTypes()\n", __FUNCTION__, __LINE__);
+
 	unsigned long off = 0;
-	while (off < img.debug_info_length)
+	while (off < img.debug_info.length)
 	{
-		DWARF_CompilationUnit* cu = (DWARF_CompilationUnit*)(img.debug_info + off);
+		DWARF_CompilationUnit* cu = (DWARF_CompilationUnit*)(img.debug_info.base + off);
 
 		DIECursor cursor(cu, (byte*)cu + sizeof(DWARF_CompilationUnit));
 		DWARF_InfoData id;
 		while (cursor.readNext(id))
 		{
-			//printf("0x%08x, level = %d, id.code = %d, id.tag = %d\n",
-			//    (unsigned char*)cu + id.entryOff - (unsigned char*)img.debug_info, cursor.level, id.code, id.tag);
+			if (debug & DbgDwarfTagRead)
+				fprintf(stderr, "%s:%d: 0x%08x, level = %d, id.code = %d, id.tag = %d\n", __FUNCTION__, __LINE__,
+						cursor.entryOff, cursor.level, id.code, id.tag);
 
 			if (id.abstract_origin)
 				mergeAbstractOrigin(id, cu);
@@ -1497,8 +1507,8 @@ bool CV2PDB::createTypes()
 						else if (id.ranges != ~0)
 						{
 							entry_point = ~0;
-							byte* r = (byte*)img.debug_ranges + id.ranges;
-							byte* rend = (byte*)img.debug_ranges + img.debug_ranges_length;
+							byte* r = (byte*)img.debug_ranges.base + id.ranges;
+							byte* rend = (byte*)img.debug_ranges.base + img.debug_ranges.length;
 							while (r < rend)
 							{
 								uint64_t pclo, pchi;
@@ -1524,7 +1534,12 @@ bool CV2PDB::createTypes()
 						}
 
 						if (entry_point)
+						{
+							if (debug & DbgPdbSyms)
+								fprintf(stderr, "%s:%d: Adding a public: %s at %x\n", __FUNCTION__, __LINE__, id.name, entry_point);
+
 							mod->AddPublic2(id.name, img.codeSegment + 1, entry_point - codeSegOff, 0);
+						}
 					}
 
 					if (id.pclo && id.pchi)
@@ -1555,10 +1570,10 @@ bool CV2PDB::createTypes()
 #if !FULL_CONTRIB
 				if (id.dir && id.name)
 				{
-					if (id.ranges > 0 && id.ranges < img.debug_ranges_length)
+					if (id.ranges > 0 && id.ranges < img.debug_ranges.length)
 					{
-						unsigned char* r = (unsigned char*)img.debug_ranges + id.ranges;
-						unsigned char* rend = (unsigned char*)img.debug_ranges + img.debug_ranges_length;
+						unsigned char* r = (unsigned char*)img.debug_ranges.base + id.ranges;
+						unsigned char* rend = (unsigned char*)img.debug_ranges.base + img.debug_ranges.length;
 						while (r < rend)
 						{
 							unsigned long pclo = RD4(r);
@@ -1644,7 +1659,7 @@ bool CV2PDB::createTypes()
 
 bool CV2PDB::createDWARFModules()
 {
-	if(!img.debug_info)
+	if(!img.debug_info.isPresent())
 		return setError("no .debug_info section found");
 
 	codeSegOff = img.getImageBase() + img.getSection(img.codeSegment).VirtualAddress;
@@ -1682,7 +1697,7 @@ bool CV2PDB::createDWARFModules()
 		appendComplex(0x52, 0x42, 12, "creal");
 	}
 
-	DIECursor::setContext(&img);
+	DIECursor::setContext(&img, debug);
 
 	countEntries = 0;
 	if (!mapTypes())
@@ -1725,10 +1740,10 @@ bool CV2PDB::createDWARFModules()
 
 bool CV2PDB::addDWARFLines()
 {
-	if(!img.debug_line)
+	if(!img.debug_line.isPresent())
 		return setError("no .debug_line section found");
 
-    if (!interpretDWARFLines(img, globalMod()))
+    if (!interpretDWARFLines(img, globalMod(), debug))
 		return setError("cannot add line number info to module");
 
     return true;
@@ -1759,7 +1774,7 @@ bool CV2PDB::writeDWARFImage(const TCHAR* opath)
 
 void CV2PDB::build_cfi_index()
 {
-	if (img.debug_frame == NULL)
+	if (!img.debug_frame.isPresent())
 		return;
 	cfi_index = new CFIIndex(img);
 }

--- a/src/dwarflines.cpp
+++ b/src/dwarflines.cpp
@@ -10,6 +10,8 @@
 #include "dwarf.h"
 #include "readDwarf.h"
 
+static DebugLevel debug;
+
 bool isRelativePath(const std::string& s)
 {
 	if(s.length() < 1)
@@ -57,11 +59,7 @@ bool _flushDWARFLines(const PEImage& img, mspdb::Mod* mod, DWARF_LineState& stat
 		// throw away invalid lines (mostly due to "set address to 0")
 		state.lineInfo.resize(0);
 		return true;
-		//return false;
 	}
-
-//    if(saddr >= 0x4000)
-//        return true;
 
 	const DWARF_FileName* dfn;
 	if(state.lineInfo_file == 0)
@@ -92,14 +90,8 @@ bool _flushDWARFLines(const PEImage& img, mspdb::Mod* mod, DWARF_LineState& stat
 		return true;
     }
 #if 1
-	bool dump = false; // (fname == "cvtest.d");
 	//qsort(&state.lineInfo[0], state.lineInfo.size(), sizeof(state.lineInfo[0]), cmpAdr);
-#if 0
-	printf("%s:\n", fname.c_str());
-	for(size_t ln = 0; ln < state.lineInfo.size(); ln++)
-		printf("  %08x: %4d\n", state.lineInfo[ln].offset + 0x401000, state.lineInfo[ln].line);
-#endif
-	
+
 	int rc = 1;
 	unsigned int low_offset = state.lineInfo[0].offset;
 	unsigned short low_line = state.lineInfo[0].line;
@@ -120,9 +112,11 @@ bool _flushDWARFLines(const PEImage& img, mspdb::Mod* mod, DWARF_LineState& stat
 	// This subtraction can underflow to (unsigned)-1 if this info is only for a single instruction, but AddLines will immediately increment it to 0, so this is fine.  Not underflowing this can cause the debugger to ignore other line info for address ranges that include this address.
 	unsigned int address_range_length = high_offset - low_offset;
 
-	if (dump)
-		printf("AddLines(%08x+%04x, Line=%4d+%3d, %s)\n", low_offset, address_range_length, low_line,
-		       state.lineInfo.size(), fname.c_str());
+	if (debug & DbgPdbLines)
+		fprintf(stderr, "%s%d: AddLines(%08x+%04x, Line=%4d+%3d, %s)\n", __FUNCTION__, __LINE__,
+				low_offset, address_range_length, low_line,
+				(unsigned int)state.lineInfo.size(), fname.c_str());
+
 	rc = mod->AddLines(fname.c_str(), segIndex + 1, low_offset, address_range_length, low_offset, low_line,
 	                   (unsigned char*)&state.lineInfo[0],
 	                   state.lineInfo.size() * sizeof(state.lineInfo[0]));
@@ -147,10 +141,6 @@ bool addLineInfo(const PEImage& img, mspdb::Mod* mod, DWARF_LineState& state)
 	if (state.end_sequence)
 		return _flushDWARFLines(img, mod, state);
 
-#if 0
-	const char* fname = (state.file == 0 ? state.file_ptr->file_name : state.files[state.file - 1].file_name);
-	printf("Adr:%08x Line: %5d File: %s\n", state.address, state.line, fname);
-#endif
 	if (state.address < state.seg_offset)
 		return true;
 	mspdb::LineInfoEntry entry;
@@ -177,15 +167,17 @@ bool addLineInfo(const PEImage& img, mspdb::Mod* mod, DWARF_LineState& state)
 	return true;
 }
 
-bool interpretDWARFLines(const PEImage& img, mspdb::Mod* mod)
+bool interpretDWARFLines(const PEImage& img, mspdb::Mod* mod, DebugLevel debug_)
 {
-	DWARF_CompilationUnit* cu = (DWARF_CompilationUnit*)img.debug_info;
+	DWARF_CompilationUnit* cu = (DWARF_CompilationUnit*)img.debug_info.base;
 	int ptrsize = cu ? cu->address_size : 4;
 
+    debug = debug_;
+
 	DWARF_LineNumberProgramHeader hdr5;
-	for(unsigned long off = 0; off < img.debug_line_length; )
+	for(unsigned long off = 0; off < img.debug_line.length; )
 	{
-		DWARF_LineNumberProgramHeader* hdrver = (DWARF_LineNumberProgramHeader*) (img.debug_line + off);
+		DWARF_LineNumberProgramHeader* hdrver = (DWARF_LineNumberProgramHeader*) (img.debug_line.base + off);
 		int length = hdrver->unit_length;
 		if(length < 0)
 			break;
@@ -285,7 +277,7 @@ bool interpretDWARFLines(const PEImage& img, mspdb::Mod* mod)
 							case DW_FORM_line_strp:
 							{
 								size_t offset = cu->isDWARF64() ? RD8(p) : RD4(p);
-								state.include_dirs.push_back(img.debug_line_str + offset);
+								state.include_dirs.push_back(img.debug_line_str.base + offset);
 								break;
 							}
 							case DW_FORM_string:
@@ -327,7 +319,7 @@ bool interpretDWARFLines(const PEImage& img, mspdb::Mod* mod)
 							case DW_FORM_line_strp:
 							{
 								size_t offset = cu->isDWARF64() ? RD8(p) : RD4(p);
-								fname.file_name = img.debug_line_str + offset;
+								fname.file_name = img.debug_line_str.base + offset;
 								break;
 							}
 							case DW_FORM_string:
@@ -387,8 +379,6 @@ bool interpretDWARFLines(const PEImage& img, mspdb::Mod* mod)
 					switch(excode)
 					{
 					case DW_LNE_end_sequence:
-						if((char*)p - img.debug_line >= 0xe4e0)
-							p = p;
 						state.end_sequence = true;
 						state.last_addr = state.address;
 						if(!addLineInfo(img, mod, state))
@@ -398,7 +388,7 @@ bool interpretDWARFLines(const PEImage& img, mspdb::Mod* mod)
 					case DW_LNE_set_address:
 					{
 						if (!mod && state.section == -1)
-							state.section = img.getRelocationInLineSegment((char*)p - img.debug_line);
+							state.section = img.getRelocationInLineSegment((char*)p - img.debug_line.base);
 						unsigned long adr = ptrsize == 8 ? RD8(p) : RD4(p);
 						state.address = adr;
 						state.op_index = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,8 @@ double
 #define T_strcpy	wcscpy
 #define T_strcat	wcscat
 #define T_strstr	wcsstr
+#define T_strncmp	wcsncmp
+#define T_strtoul	wcstoul
 #define T_strtod	wcstod
 #define T_strrchr	wcsrchr
 #define T_unlink	_wremove
@@ -34,6 +36,8 @@ double
 #define T_strcpy	strcpy
 #define T_strcat	strcat
 #define T_strstr	strstr
+#define T_strncmp	strncmp
+#define T_strtoul	strtoul
 #define T_strtod	strtod
 #define T_strrchr	strrchr
 #define T_unlink	unlink
@@ -120,7 +124,7 @@ int T_main(int argc, TCHAR* argv[])
 {
 	double Dversion = 2.072;
 	const TCHAR* pdbref = 0;
-	bool debug = false;
+	DebugLevel debug = DebugLevel{};
 
 	CoInitialize(nullptr);
 
@@ -138,8 +142,15 @@ int T_main(int argc, TCHAR* argv[])
 			demangleSymbols = false;
 		else if (argv[0][1] == 'e')
 			useTypedefEnum = true;
-		else if (argv[0][1] == 'd' && argv[0][2] == 'e' && argv[0][3] == 'b') // deb[ug]
-			debug = true;
+		else if (!T_strncmp(&argv[0][1], TEXT("debug"), 5)) // debug[level]
+		{
+			debug = (DebugLevel)T_strtoul(&argv[0][6], 0, 0);
+			if (!debug) {
+				debug = DbgBasic;
+			}
+
+			fprintf(stderr, "Debug set to %x\n", debug);
+		}
 		else if (argv[0][1] == 's' && argv[0][2])
 			dotReplacementChar = (char)argv[0][2];
 		else if (argv[0][1] == 'p' && argv[0][2])
@@ -182,9 +193,8 @@ int T_main(int argc, TCHAR* argv[])
 		img = &dbg;
 	}
 
-	CV2PDB cv2pdb(*img);
+	CV2PDB cv2pdb(*img, debug);
 	cv2pdb.Dversion = Dversion;
-	cv2pdb.debug = debug;
 	cv2pdb.initLibraries();
 
 	TCHAR* outname = argv[1];

--- a/src/readDwarf.cpp
+++ b/src/readDwarf.cpp
@@ -1,14 +1,37 @@
 #include "readDwarf.h"
 #include <assert.h>
-#include <unordered_map>
 #include <array>
-#include <windows.h>
 
 #include "PEImage.h"
 #include "dwarf.h"
 #include "mspdb.h"
 extern "C" {
 	#include "mscvpdb.h"
+}
+
+
+// declare hasher for pair<T1,T2>
+namespace std
+{
+template<typename T1, typename T2>
+struct hash<std::pair<T1, T2>>
+{
+	size_t operator()(const std::pair<T1, T2>& t) const
+	{
+		return std::hash<T1>()(t.first) ^ std::hash<T2>()(t.second);
+	}
+};
+}
+
+PEImage* DIECursor::img;
+abbrevMap_t DIECursor::abbrevMap;
+DebugLevel DIECursor::debug;
+
+void DIECursor::setContext(PEImage* img_, DebugLevel debug_)
+{
+	img = img_;
+	abbrevMap.clear();
+	debug = debug_;
 }
 
 static Location mkInReg(unsigned reg)
@@ -320,31 +343,6 @@ void mergeSpecification(DWARF_InfoData& id, DWARF_CompilationUnit* cu)
 	id.merge(idspec);
 }
 
-// declare hasher for pair<T1,T2>
-namespace std
-{
-	template<typename T1, typename T2>
-	struct hash<std::pair<T1, T2>>
-	{
-		size_t operator()(const std::pair<T1, T2>& t) const
-		{
-			return std::hash<T1>()(t.first) ^ std::hash<T2>()(t.second);
-		}
-	};
-}
-
-typedef std::unordered_map<std::pair<unsigned, unsigned>, byte*> abbrevMap_t;
-
-static PEImage* img;
-static abbrevMap_t abbrevMap;
-
-void DIECursor::setContext(PEImage* img_)
-{
-	img = img_;
-	abbrevMap.clear();
-}
-
-
 DIECursor::DIECursor(DWARF_CompilationUnit* cu_, byte* ptr_)
 {
 	cu = cu_;
@@ -415,7 +413,7 @@ bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
 			return false; // root of the tree does not have a null terminator, but we know the length
 
 		id.entryPtr = ptr;
-		id.entryOff = ptr - (byte*)cu;
+		entryOff = img->debug_info.sectOff(ptr);
 		id.code = LEB128(ptr);
 		if (id.code == 0)
 		{
@@ -432,13 +430,18 @@ bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
 	}
 
 	byte* abbrev = getDWARFAbbrev(cu->debug_abbrev_offset, id.code);
-	assert(abbrev);
-	if (!abbrev)
+	if (!abbrev) {
+		fprintf(stderr, "ERROR: %s:%d: unknown abbrev: num=%d off=%x\n", __FUNCTION__, __LINE__, id.code, entryOff);
+		assert(abbrev);
 		return false;
+	}
 
 	id.abbrev = abbrev;
 	id.tag = LEB128(abbrev);
 	id.hasChild = *abbrev++;
+	
+	if (debug & DbgDwarfAttrRead)
+		fprintf(stderr, "%s:%d: offs=%d level=%d tag=%d abbrev=%d\n", __FUNCTION__, __LINE__, entryOff, level, id.tag, id.code);
 
 	int attr, form;
 	for (;;)
@@ -449,8 +452,14 @@ bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
 		if (attr == 0 && form == 0)
 			break;
 
-		while (form == DW_FORM_indirect)
+		if (debug & DbgDwarfAttrRead)
+			fprintf(stderr, "%s:%d: offs=%x, attr=%d, form=%d\n", __FUNCTION__, __LINE__, attr, form, img->debug_info.sectOff(ptr));
+
+		while (form == DW_FORM_indirect) {
 			form = LEB128(ptr);
+			if (debug & DbgDwarfAttrRead)
+				fprintf(stderr, "%s:%d: attr=%d, form=%d\n", __FUNCTION__, __LINE__, attr, form);
+		}
 
 		DWARF_Attribute a;
 		switch (form)
@@ -467,7 +476,7 @@ bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
 			case DW_FORM_sdata:          a.type = Const; a.cons = SLEB128(ptr); break;
 			case DW_FORM_udata:          a.type = Const; a.cons = LEB128(ptr); break;
 			case DW_FORM_string:         a.type = String; a.string = (const char*)ptr; ptr += strlen(a.string) + 1; break;
-            case DW_FORM_strp:           a.type = String; a.string = (const char*)(img->debug_str + RDsize(ptr, cu->isDWARF64() ? 8 : 4)); break;
+            case DW_FORM_strp:           a.type = String; a.string = (const char*)(img->debug_str.base + RDsize(ptr, cu->isDWARF64() ? 8 : 4)); break;
 			case DW_FORM_flag:           a.type = Flag; a.flag = (*ptr++ != 0); break;
 			case DW_FORM_flag_present:   a.type = Flag; a.flag = true; break;
 			case DW_FORM_ref1:           a.type = Ref; a.ref = (byte*)cu + *ptr++; break;
@@ -475,7 +484,7 @@ bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
 			case DW_FORM_ref4:           a.type = Ref; a.ref = (byte*)cu + RD4(ptr); break;
 			case DW_FORM_ref8:           a.type = Ref; a.ref = (byte*)cu + RD8(ptr); break;
 			case DW_FORM_ref_udata:      a.type = Ref; a.ref = (byte*)cu + LEB128(ptr); break;
-			case DW_FORM_ref_addr:       a.type = Ref; a.ref = (byte*)img->debug_info + (cu->isDWARF64() ? RD8(ptr) : RD4(ptr)); break;
+			case DW_FORM_ref_addr:       a.type = Ref; a.ref = (byte*)img->debug_info.base + (cu->isDWARF64() ? RD8(ptr) : RD4(ptr)); break;
 			case DW_FORM_ref_sig8:       a.type = Invalid; ptr += 8;  break;
 			case DW_FORM_exprloc:        a.type = ExprLoc; a.expr.len = LEB128(ptr); a.expr.ptr = ptr; ptr += a.expr.len; break;
 			case DW_FORM_sec_offset:     a.type = SecOffset;  a.sec_offset = cu->isDWARF64() ? RD8(ptr) : RD4(ptr); break;
@@ -578,7 +587,7 @@ bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
 
 byte* DIECursor::getDWARFAbbrev(unsigned off, unsigned findcode)
 {
-	if (!img->debug_abbrev)
+	if (!img->debug_abbrev.isPresent())
 		return 0;
 
 	std::pair<unsigned, unsigned> key = std::make_pair(off, findcode);
@@ -588,8 +597,8 @@ byte* DIECursor::getDWARFAbbrev(unsigned off, unsigned findcode)
 		return it->second;
 	}
 
-	byte* p = (byte*)img->debug_abbrev + off;
-	byte* end = (byte*)img->debug_abbrev + img->debug_abbrev_length;
+	byte* p = (byte*)img->debug_abbrev.base + off;
+	byte* end = (byte*)img->debug_abbrev.base + img->debug_abbrev.length;
 	while (p < end)
 	{
 		int code = LEB128(p);


### PR DESCRIPTION
Encapsulate dwarf-related PE sections into a new class.  Remove some
unused sections.

Move the context set via DIECursor::setContext to be static members of
the class and add a debug context there.

Add a standard method of enabling debug logging across the dwarf and PDB
code.

These are prep changes for supporting DWARF5