### PR TITLE
Add support for Dwarf5 as emitted by gcc-11.2

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,4 +52,9 @@ jobs:
 
           gcc -g -o hello.exe hello.c &&
           bin/${{env.BUILD_CONFIGURATION}}*/cv2pdb.exe hello.exe world.exe &&
-          ls -l hello* world*
+
+          ls -l hello* world* &&
+
+          curl -Lo cvdump.exe https://raw.githubusercontent.com/microsoft/microsoft-pdb/HEAD/cvdump/cvdump.exe &&
+          ./cvdump.exe world.pdb >world.cvdump &&
+          grep '^S_PUB32: .*, Flags: 00000000, main$' world.cvdump

--- a/src/PEImage.cpp
+++ b/src/PEImage.cpp
@@ -35,19 +35,6 @@ PEImage::PEImage(const TCHAR* iname)
 , hdr32(0)
 , hdr64(0)
 , fd(-1)
-, debug_aranges(0)
-, debug_pubnames(0)
-, debug_pubtypes(0)
-, debug_info(0), debug_info_length(0)
-, debug_abbrev(0), debug_abbrev_length(0)
-, debug_line(0), debug_line_length(0)
-, debug_frame(0), debug_frame_length(0)
-, debug_str(0)
-, debug_loc(0), debug_loc_length(0)
-, debug_ranges(0), debug_ranges_length(0)
-, codeSegment(0)
-, linesSegment(-1)
-, reloc(0), reloc_length(0)
 , nsec(0)
 , nsym(0)
 , symtable(0)
@@ -470,6 +457,15 @@ static DWORD sizeInImage(const IMAGE_SECTION_HEADER& sec)
     return sec.SizeOfRawData < sec.Misc.VirtualSize ? sec.SizeOfRawData : sec.Misc.VirtualSize;
 }
 
+void PEImage::initSec(PESection& peSec, int secNo) const
+{
+	auto &imgSec = sec[secNo];
+
+	peSec.length = sizeInImage(imgSec);
+	peSec.base = DPV<byte>(imgSec.PointerToRawData, peSec.length);
+	peSec.secNo = secNo;
+}
+
 void PEImage::initDWARFSegments()
 {
 	for(int s = 0; s < nsec; s++)
@@ -480,49 +476,30 @@ void PEImage::initDWARFSegments()
 			int off = strtol(name + 1, 0, 10);
 			name = strtable + off;
 		}
-		if(strcmp(name, ".debug_aranges") == 0)
-			debug_aranges = DPV<char>(sec[s].PointerToRawData, sizeInImage(sec[s]));
-		if(strcmp(name, ".debug_pubnames") == 0)
-			debug_pubnames = DPV<char>(sec[s].PointerToRawData, sizeInImage(sec[s]));
-		if(strcmp(name, ".debug_pubtypes") == 0)
-			debug_pubtypes = DPV<char>(sec[s].PointerToRawData, sizeInImage(sec[s]));
-		if(strcmp(name, ".debug_info") == 0)
-			debug_info = DPV<char>(sec[s].PointerToRawData, debug_info_length = sizeInImage(sec[s]));
-		if(strcmp(name, ".debug_abbrev") == 0)
-			debug_abbrev = DPV<char>(sec[s].PointerToRawData, debug_abbrev_length = sizeInImage(sec[s]));
-		if(strcmp(name, ".debug_line") == 0)
-			debug_line = DPV<char>(sec[linesSegment = s].PointerToRawData, debug_line_length = sizeInImage(sec[s]));
-		if (strcmp(name, ".debug_line_str") == 0)
-			debug_line_str = DPV<char>(sec[s].PointerToRawData, debug_line_str_length = sizeInImage(sec[s]));
-		if(strcmp(name, ".debug_frame") == 0)
-			debug_frame = DPV<char>(sec[s].PointerToRawData, debug_frame_length = sizeInImage(sec[s]));
-		if(strcmp(name, ".debug_str") == 0)
-			debug_str = DPV<char>(sec[s].PointerToRawData, sizeInImage(sec[s]));
-		if(strcmp(name, ".debug_loc") == 0)
-			debug_loc = DPV<char>(sec[s].PointerToRawData, debug_loc_length = sizeInImage(sec[s]));
-		if(strcmp(name, ".debug_ranges") == 0)
-			debug_ranges = DPV<char>(sec[s].PointerToRawData, debug_ranges_length = sizeInImage(sec[s]));
-		if(strcmp(name, ".reloc") == 0)
-			reloc = DPV<char>(sec[s].PointerToRawData, reloc_length = sizeInImage(sec[s]));
-		if(strcmp(name, ".text") == 0)
-			codeSegment = s;
+
+		for (const SectionDescriptor *sec_desc : sec_descriptors) {
+			if (!strcmp(name, sec_desc->name)) {
+				PESection& peSec = this->*(sec_desc->pSec);
+				initSec(peSec, s);
+			}
+		}
 	}
 }
 
 bool PEImage::relocateDebugLineInfo(unsigned int img_base)
 {
-	if(!reloc || !reloc_length)
+	if(!reloc.isPresent())
 		return true;
 
-	char* relocbase = reloc;
-	char* relocend = reloc + reloc_length;
+	byte* relocbase = reloc.startByte();
+	byte* relocend = reloc.endByte();
 	while(relocbase < relocend)
 	{
 		unsigned int virtadr = *(unsigned int *) relocbase;
 		unsigned int chksize = *(unsigned int *) (relocbase + 4);
 
 		char* p = RVA<char> (virtadr, 1);
-		if(p >= debug_line && p < debug_line + debug_line_length)
+		if(debug_line.isPtrInside(p))
 		{
 			for (unsigned int w = 8; w < chksize; w += 2)
 			{
@@ -536,7 +513,7 @@ bool PEImage::relocateDebugLineInfo(unsigned int img_base)
 				}
 			}
 		}
-		if(chksize == 0 || chksize >= reloc_length)
+		if(chksize == 0 || chksize >= reloc.length)
 			break;
 		relocbase += chksize;
 	}
@@ -545,7 +522,7 @@ bool PEImage::relocateDebugLineInfo(unsigned int img_base)
 
 int PEImage::getRelocationInLineSegment(unsigned int offset) const
 {
-    return getRelocationInSegment(linesSegment, offset);
+    return getRelocationInSegment(debug_line.secNo, offset);
 }
 
 int PEImage::getRelocationInSegment(int segment, unsigned int offset) const

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -279,11 +279,6 @@ public:
 	// Default lower bound for the current compilation unit. This depends on
 	// the language of the current unit.
 	unsigned currentDefaultLowerBound;
-
-	// Value of the DW_AT_low_pc attribute for the current compilation unit.
-	// Specify the default base address for use in location lists and range
-	// lists.
-	uint32_t currentBaseAddress;
 };
 
 #endif //__CV2PDB_H__

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -15,7 +15,6 @@
 
 #include <windows.h>
 #include <map>
-#include <unordered_map>
 
 extern "C" {
 	#include "mscvpdb.h"
@@ -172,17 +171,17 @@ public:
 	bool writeDWARFImage(const TCHAR* opath);
 
 	bool addDWARFSectionContrib(mspdb::Mod* mod, unsigned long pclo, unsigned long pchi);
-	bool addDWARFProc(DWARF_InfoData& id, DWARF_CompilationUnit* cu, DIECursor cursor);
-	int  addDWARFStructure(DWARF_InfoData& id, DWARF_CompilationUnit* cu, DIECursor cursor);
-	int  addDWARFFields(DWARF_InfoData& structid, DWARF_CompilationUnit* cu, DIECursor cursor, int off);
-	int  addDWARFArray(DWARF_InfoData& arrayid, DWARF_CompilationUnit* cu, DIECursor cursor);
+	bool addDWARFProc(DWARF_InfoData& id, DIECursor cursor);
+	int  addDWARFStructure(DWARF_InfoData& id, DIECursor cursor);
+	int  addDWARFFields(DWARF_InfoData& structid, DIECursor cursor, int off);
+	int  addDWARFArray(DWARF_InfoData& arrayid, DIECursor cursor);
 	int  addDWARFBasicType(const char*name, int encoding, int byte_size);
-	int  addDWARFEnum(DWARF_InfoData& enumid, DWARF_CompilationUnit* cu, DIECursor cursor);
-	int  getTypeByDWARFPtr(DWARF_CompilationUnit* cu, byte* ptr);
-	int  getDWARFTypeSize(DWARF_CompilationUnit* cu, byte* ptr);
-	void getDWARFArrayBounds(DWARF_InfoData& arrayid, DWARF_CompilationUnit* cu, DIECursor cursor,
+	int  addDWARFEnum(DWARF_InfoData& enumid, DIECursor cursor);
+	int  getTypeByDWARFPtr(byte* ptr);
+	int  getDWARFTypeSize(const DIECursor& parent, byte* ptr);
+	void getDWARFArrayBounds(DWARF_InfoData& arrayid, DIECursor cursor,
 		int& basetype, int& lowerBound, int& upperBound);
-	void getDWARFSubrangeInfo(DWARF_InfoData& subrangeid, DWARF_CompilationUnit* cu,
+	void getDWARFSubrangeInfo(DWARF_InfoData& subrangeid, const DIECursor& parent,
 		int& basetype, int& lowerBound, int& upperBound);
 	int getDWARFBasicType(int encoding, int byte_size);
 

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -30,7 +30,7 @@ class CFIIndex;
 class CV2PDB : public LastError
 {
 public:
-	CV2PDB(PEImage& image);
+	CV2PDB(PEImage& image, DebugLevel debug);
 	~CV2PDB();
 
 	bool cleanup(bool commit);
@@ -265,7 +265,7 @@ public:
 	bool useGlobalMod;
 	bool thisIsNotRef;
 	bool v3;
-	bool debug;
+	DebugLevel debug;
 	const char* lastError;
 
 	int srcLineSections;

--- a/src/dwarf.h
+++ b/src/dwarf.h
@@ -229,10 +229,32 @@ extern "C" {
 #define DW_FORM_flag_present            0x19 /* DWARF4 */
 #define DW_FORM_strx                    0x1a /* DWARF5 */
 #define DW_FORM_addrx                   0x1b /* DWARF5 */
+#define DW_FORM_ref_sup4                0x1c /* DWARF5 */
 #define DW_FORM_strp_sup                0x1d /* DWARF5 */
 #define DW_FORM_data16                  0x1e /* DWARF5 */
 #define DW_FORM_line_strp               0x1f /* DWARF5 */
 #define DW_FORM_ref_sig8                0x20 /* DWARF4 */
+#define DW_FORM_implicit_const          0x21 /* DWARF5 */
+#define DW_FORM_loclistx                0x22 /* DWARF5 */
+#define DW_FORM_rnglistx                0x23 /* DWARF5 */
+#define DW_FORM_ref_sup8                0x24 /* DWARF5 */
+#define DW_FORM_strx1                   0x25 /* DWARF5 */
+#define DW_FORM_strx2                   0x26 /* DWARF5 */
+#define DW_FORM_strx3                   0x27 /* DWARF5 */
+#define DW_FORM_strx4                   0x28 /* DWARF5 */
+#define DW_FORM_addrx1                  0x29 /* DWARF5 */
+#define DW_FORM_addrx2                  0x2a /* DWARF5 */
+#define DW_FORM_addrx3                  0x2b /* DWARF5 */
+#define DW_FORM_addrx4                  0x2c /* DWARF5 */
+
+#define DW_UT_compile                   0x01 /* DWARF5 */
+#define DW_UT_type                      0x02 /* DWARF5 */
+#define DW_UT_partial                   0x03 /* DWARF5 */
+#define DW_UT_skeleton                  0x04 /* DWARF5 */
+#define DW_UT_split_compile             0x05 /* DWARF5 */
+#define DW_UT_split_type                0x06 /* DWARF5 */
+#define DW_UT_lo_user                   0x80 /* DWARF5 */
+#define DW_UT_hi_user                   0xff /* DWARF5 */
 
 #define DW_AT_sibling                           0x01
 #define DW_AT_location                          0x02
@@ -331,6 +353,35 @@ extern "C" {
 #define DW_AT_const_expr                        0x6c /* DWARF4 */
 #define DW_AT_enum_class                        0x6d /* DWARF4 */
 #define DW_AT_linkage_name                      0x6e /* DWARF4 */
+#define DW_AT_string_length_bit_size            0x6f /* DWARF5 */
+#define DW_AT_string_length_byte_size           0x70 /* DWARF5 */
+#define DW_AT_rank                              0x71 /* DWARF5 */
+#define DW_AT_str_offsets_base                  0x72 /* DWARF5 */
+#define DW_AT_addr_base                         0x73 /* DWARF5 */
+#define DW_AT_rnglists_base                     0x74 /* DWARF5 */
+#define DW_AT_dwo_name                          0x76 /* DWARF5 */
+#define DW_AT_reference                         0x77 /* DWARF5 */
+#define DW_AT_rvalue_reference                  0x78 /* DWARF5 */
+#define DW_AT_macros                            0x79 /* DWARF5 */
+#define DW_AT_call_all_calls                    0x7a /* DWARF5 */
+#define DW_AT_call_all_source_calls             0x7b /* DWARF5 */
+#define DW_AT_call_all_tail_calls               0x7c /* DWARF5 */
+#define DW_AT_call_return_pc                    0x7d /* DWARF5 */
+#define DW_AT_call_value                        0x7e /* DWARF5 */
+#define DW_AT_call_origin                       0x7f /* DWARF5 */
+#define DW_AT_call_parameter                    0x80 /* DWARF5 */
+#define DW_AT_call_pc                           0x81 /* DWARF5 */
+#define DW_AT_call_tail_call                    0x82 /* DWARF5 */
+#define DW_AT_call_target                       0x83 /* DWARF5 */
+#define DW_AT_call_target_clobbered             0x84 /* DWARF5 */
+#define DW_AT_call_data_location                0x85 /* DWARF5 */
+#define DW_AT_call_data_value                   0x86 /* DWARF5 */
+#define DW_AT_noreturn                          0x87 /* DWARF5 */
+#define DW_AT_alignment                         0x88 /* DWARF5 */
+#define DW_AT_export_symbols                    0x89 /* DWARF5 */
+#define DW_AT_deleted                           0x8a /* DWARF5 */
+#define DW_AT_defaulted                         0x8b /* DWARF5 */
+#define DW_AT_loclists_base                     0x8c /* DWARF5 */
 
 /* In extensions, we attempt to include the vendor extension
    in the name even when the vendor leaves it out. */
@@ -901,6 +952,27 @@ extern "C" {
 #define DW_LNE_HP_source_file_correlation   0x80 /* HP */
 #define DW_LNE_lo_user                  0x80 /* DWARF3 */
 #define DW_LNE_hi_user                  0xff /* DWARF3 */
+
+/* DWARF5 debug_rnglists entries */
+#define DW_RLE_end_of_list              0x00
+#define DW_RLE_base_addressx            0x01
+#define DW_RLE_startx_endx              0x02
+#define DW_RLE_startx_length            0x03
+#define DW_RLE_offset_pair              0x04
+#define DW_RLE_base_address             0x05
+#define DW_RLE_start_end                0x06
+#define DW_RLE_start_length             0x07
+
+/* DWARF5 debug_loclists entries */
+#define DW_LLE_end_of_list              0x00
+#define DW_LLE_base_addressx            0x01
+#define DW_LLE_startx_endx              0x02
+#define DW_LLE_startx_length            0x03
+#define DW_LLE_offset_pair              0x04
+#define DW_LLE_default_location         0x05
+#define DW_LLE_base_address             0x06
+#define DW_LLE_start_end                0x07
+#define DW_LLE_start_length             0x08
 
 /* These are known values for DW_LNS_set_isa. */
 #define DW_ISA_UNKNOWN   0

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -1294,16 +1294,26 @@ bool CV2PDB::mapTypes()
 	while (off < img.debug_info.length)
 	{
 		DWARF_CompilationUnitInfo cu{};
-		byte* ptr = cu.read(img, &off);
+		byte* ptr = cu.read(debug, img, &off);
 		if (!ptr)
 			continue;
+
+		if (cu.unit_type != DW_UT_compile) {
+			if (debug & DbgDwarfCompilationUnit)
+				fprintf(stderr, "%s:%d: skipping compilation unit offs=%x, unit_type=%d\n", __FUNCTION__, __LINE__,
+						cu.cu_offset, cu.unit_type);
+
+			continue;
+		}
 
 		DIECursor cursor(&cu, ptr);
 		DWARF_InfoData id;
 		while (cursor.readNext(id))
 		{
-			//printf("0x%08x, level = %d, id.code = %d, id.tag = %d\n",
-			//    (unsigned char*)cu + id.entryOff - (unsigned char*)img.debug_info, cursor.level, id.code, id.tag);
+			if (debug & DbgDwarfTagRead)
+				fprintf(stderr, "%s:%d: 0x%08x, level = %d, id.code = %d, id.tag = %d\n", __FUNCTION__, __LINE__,
+						cursor.entryOff, cursor.level, id.code, id.tag);
+
 			switch (id.tag)
 			{
 				case DW_TAG_base_type:
@@ -1359,9 +1369,17 @@ bool CV2PDB::createTypes()
 	while (off < img.debug_info.length)
 	{
 		DWARF_CompilationUnitInfo cu{};
-		byte* ptr = cu.read(img, &off);
+		byte* ptr = cu.read(debug, img, &off);
 		if (!ptr)
 			continue;
+
+		if (cu.unit_type != DW_UT_compile) {
+			if (debug & DbgDwarfCompilationUnit)
+				fprintf(stderr, "%s:%d: skipping compilation unit offs=%x, unit_type=%d\n", __FUNCTION__, __LINE__,
+						cu.cu_offset, cu.unit_type);
+
+			continue;
+		}
 
 		DIECursor cursor(&cu, ptr);
 		DWARF_InfoData id;

--- a/src/dwarflines.cpp
+++ b/src/dwarflines.cpp
@@ -169,8 +169,13 @@ bool addLineInfo(const PEImage& img, mspdb::Mod* mod, DWARF_LineState& state)
 
 bool interpretDWARFLines(const PEImage& img, mspdb::Mod* mod, DebugLevel debug_)
 {
-	DWARF_CompilationUnit* cu = (DWARF_CompilationUnit*)img.debug_info.startByte();
-	int ptrsize = cu ? cu->address_size : 4;
+	DWARF_CompilationUnitInfo cu{};
+
+	if (!cu.read(img, 0)) {
+		return false;
+	}
+
+	int ptrsize = cu.address_size;
 
 	debug = debug_;
 
@@ -280,7 +285,7 @@ bool interpretDWARFLines(const PEImage& img, mspdb::Mod* mod, DebugLevel debug_)
 							{
 							case DW_FORM_line_strp:
 							{
-								size_t offset = cu->isDWARF64() ? RD8(p) : RD4(p);
+								size_t offset = cu.isDWARF64() ? RD8(p) : RD4(p);
 								state.include_dirs.push_back((const char*)img.debug_line_str.byteAt(offset));
 								break;
 							}
@@ -322,7 +327,7 @@ bool interpretDWARFLines(const PEImage& img, mspdb::Mod* mod, DebugLevel debug_)
 							{
 							case DW_FORM_line_strp:
 							{
-								size_t offset = cu->isDWARF64() ? RD8(p) : RD4(p);
+								size_t offset = cu.isDWARF64() ? RD8(p) : RD4(p);
 								fname.file_name = (const char*)img.debug_line_str.byteAt(offset);
 								break;
 							}

--- a/src/dwarflines.cpp
+++ b/src/dwarflines.cpp
@@ -169,9 +169,11 @@ bool addLineInfo(const PEImage& img, mspdb::Mod* mod, DWARF_LineState& state)
 
 bool interpretDWARFLines(const PEImage& img, mspdb::Mod* mod, DebugLevel debug_)
 {
+
 	DWARF_CompilationUnitInfo cu{};
 
-	if (!cu.read(img, 0)) {
+	unsigned long offs = 0;
+	if (!cu.read(debug_, img, &offs)) {
 		return false;
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,8 @@ double
 #define T_strcpy	wcscpy
 #define T_strcat	wcscat
 #define T_strstr	wcsstr
+#define T_strncmp	wcsncmp
+#define T_strtoul	wcstoul
 #define T_strtod	wcstod
 #define T_strrchr	wcsrchr
 #define T_unlink	_wremove
@@ -34,6 +36,8 @@ double
 #define T_strcpy	strcpy
 #define T_strcat	strcat
 #define T_strstr	strstr
+#define T_strncmp	strncmp
+#define T_strtoul	strtoul
 #define T_strtod	strtod
 #define T_strrchr	strrchr
 #define T_unlink	unlink
@@ -120,7 +124,7 @@ int T_main(int argc, TCHAR* argv[])
 {
 	double Dversion = 2.072;
 	const TCHAR* pdbref = 0;
-	bool debug = false;
+	DebugLevel debug = DebugLevel{};
 
 	CoInitialize(nullptr);
 
@@ -138,8 +142,15 @@ int T_main(int argc, TCHAR* argv[])
 			demangleSymbols = false;
 		else if (argv[0][1] == 'e')
 			useTypedefEnum = true;
-		else if (argv[0][1] == 'd' && argv[0][2] == 'e' && argv[0][3] == 'b') // deb[ug]
-			debug = true;
+		else if (!T_strncmp(&argv[0][1], TEXT("debug"), 5)) // debug[level]
+		{
+			debug = (DebugLevel)T_strtoul(&argv[0][6], 0, 0);
+			if (!debug) {
+				debug = DbgBasic;
+			}
+
+			fprintf(stderr, "Debug set to %x\n", debug);
+		}
 		else if (argv[0][1] == 's' && argv[0][2])
 			dotReplacementChar = (char)argv[0][2];
 		else if (argv[0][1] == 'p' && argv[0][2])
@@ -182,9 +193,8 @@ int T_main(int argc, TCHAR* argv[])
 		img = &dbg;
 	}
 
-	CV2PDB cv2pdb(*img);
+	CV2PDB cv2pdb(*img, debug);
 	cv2pdb.Dversion = Dversion;
-	cv2pdb.debug = debug;
 	cv2pdb.initLibraries();
 
 	TCHAR* outname = argv[1];

--- a/src/readDwarf.cpp
+++ b/src/readDwarf.cpp
@@ -315,31 +315,31 @@ Location decodeLocation(const PEImage& img, const DWARF_Attribute& attr, const L
 	return stack[0];
 }
 
-void mergeAbstractOrigin(DWARF_InfoData& id, DWARF_CompilationUnit* cu)
+void mergeAbstractOrigin(DWARF_InfoData& id, const DIECursor& parent)
 {
-	DIECursor specCursor(cu, id.abstract_origin);
+	DIECursor specCursor(parent, id.abstract_origin);
 	DWARF_InfoData idspec;
 	specCursor.readNext(idspec);
 	// assert seems invalid, combination DW_TAG_member and DW_TAG_variable found in the wild
 	// assert(id.tag == idspec.tag);
 	if (idspec.abstract_origin)
-		mergeAbstractOrigin(idspec, cu);
+		mergeAbstractOrigin(idspec, parent);
 	if (idspec.specification)
-		mergeSpecification(idspec, cu);
+		mergeSpecification(idspec, parent);
 	id.merge(idspec);
 }
 
-void mergeSpecification(DWARF_InfoData& id, DWARF_CompilationUnit* cu)
+void mergeSpecification(DWARF_InfoData& id, const DIECursor& parent)
 {
-	DIECursor specCursor(cu, id.specification);
+	DIECursor specCursor(parent, id.specification);
 	DWARF_InfoData idspec;
 	specCursor.readNext(idspec);
 	//assert seems invalid, combination DW_TAG_member and DW_TAG_variable found in the wild
 	//assert(id.tag == idspec.tag);
 	if (idspec.abstract_origin)
-		mergeAbstractOrigin(idspec, cu);
+		mergeAbstractOrigin(idspec, parent);
 	if (idspec.specification)
-		mergeSpecification(idspec, cu);
+		mergeSpecification(idspec, parent);
 	id.merge(idspec);
 }
 
@@ -352,6 +352,11 @@ DIECursor::DIECursor(DWARF_CompilationUnit* cu_, byte* ptr_)
 	sibling = 0;
 }
 
+DIECursor::DIECursor(const DIECursor& parent, byte* ptr_)
+	: DIECursor(parent)
+{
+	ptr = ptr_;
+}
 
 void DIECursor::gotoSibling()
 {

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -11,6 +11,7 @@
 typedef unsigned char byte;
 class PEImage;
 class DIECursor;
+struct SectionDescriptor;
 
 enum DebugLevel : unsigned {
 	DbgBasic = 0x1,
@@ -138,6 +139,18 @@ struct DWARF_CompilationUnitInfo
 	// lists.
 	uint32_t base_address;
 
+	// Indirect base address in .debug_addr for addrx forms
+	byte* addr_base;
+
+	// Indirect base address in .debug_str_offsets for strx forms
+	byte* str_offset_base;
+
+	// Indirect base address in .debug_loclists for loclistx forms
+	byte* loclist_base;
+
+	// Indirect base address in the .debug_rnglists for rnglistx forms
+	byte* rnglist_base;
+
 	// Offset within the debug_info section
 	uint32_t cu_offset;
 	byte* start_ptr;
@@ -148,7 +161,6 @@ struct DWARF_CompilationUnitInfo
 	byte* read(DebugLevel debug, const PEImage& img, unsigned long *off);
 
 	bool isDWARF64() const { return is_dwarf64; }
-	int refSize() const { return isDWARF64() ? 8 : 4; }
 };
 
 struct DWARF_FileName
@@ -526,6 +538,15 @@ public:
 
 		return RD8(p);
 	}
+
+	unsigned long long RDref(byte* &ptr) const { return cu->isDWARF64() ? RD8(ptr) : RD4(ptr); }
+	int refSize() const { return cu->isDWARF64() ? 8 : 4; }
+
+	// Obtain the address of a string for a strx form.
+	const char *resolveIndirectString(uint32_t index) const ;
+	uint32_t readIndirectAddr(uint32_t index) const ;
+	uint32_t resolveIndirectSecPtr(uint32_t index, const SectionDescriptor &secDesc, byte *baseAddress) const;
+
 };
 
 // iterate over DWARF debug_line information

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -18,11 +18,12 @@ enum DebugLevel : unsigned {
 	DbgPdbSyms = 0x4,
 	DbgPdbLines = 0x8,
 	DbgPdbContrib = 0x10,
-	DbgDwarfTagRead = 0x100,
-	DbgDwarfAttrRead = 0x200,
-	DbgDwarfLocLists = 0x400,
-	DbgDwarfRangeLists = 0x800,
-	DbgDwarfLines = 0x1000
+	DbgDwarfCompilationUnit = 0x100,
+	DbgDwarfTagRead = 0x200,
+	DbgDwarfAttrRead = 0x400,
+	DbgDwarfLocLists = 0x800,
+	DbgDwarfRangeLists = 0x1000,
+	DbgDwarfLines = 0x2000
 };
 
 DEFINE_ENUM_FLAG_OPERATORS(DebugLevel);
@@ -144,7 +145,7 @@ struct DWARF_CompilationUnitInfo
 
 	bool is_dwarf64;
 
-	byte* read(const PEImage& img, unsigned long *off);
+	byte* read(DebugLevel debug, const PEImage& img, unsigned long *off);
 
 	bool isDWARF64() const { return is_dwarf64; }
 	int refSize() const { return isDWARF64() ? 8 : 4; }

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -435,7 +435,14 @@ class LOCEntry
 public:
 	unsigned long beg_offset;
 	unsigned long end_offset;
+	bool isDefault;
 	Location loc;
+
+	void addBase(uint32_t base)
+	{
+		beg_offset += base;
+		end_offset += base;
+	}
 };
 
 // Location list cursor
@@ -445,8 +452,10 @@ public:
 	LOCCursor(const DIECursor& parent, unsigned long off);
 
 	const DIECursor& parent;
+	uint32_t base;
 	byte* end;
 	byte* ptr;
+	bool isLocLists;
 
 	bool readNext(LOCEntry& entry);
 };
@@ -472,8 +481,10 @@ public:
 	RangeCursor(const DIECursor& parent, unsigned long off);
 
 	const DIECursor& parent;
+	uint32_t base;
 	byte *end;
 	byte *ptr;
+	bool isRngLists;
 
 	bool readNext(RangeEntry& entry);
 };

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -165,7 +165,7 @@ struct DWARF_CompilationUnitInfo
 
 struct DWARF_FileName
 {
-	const char* file_name;
+	std::string file_name;
 	unsigned int  dir_index;
 	unsigned long lastModification;
 	unsigned long fileLength;
@@ -173,7 +173,7 @@ struct DWARF_FileName
 	void read(byte* &p)
 	{
 		file_name = (const char*)p;
-		p += strlen((const char*)p) + 1;
+		p += file_name.size() + 1;
 		dir_index = LEB128(p);
 		lastModification = LEB128(p);
 		fileLength = LEB128(p);
@@ -345,7 +345,7 @@ struct DWARF2_LineNumberProgramHeader
 struct DWARF_LineState
 {
 	// hdr info
-	std::vector<const char*> include_dirs;
+	std::vector<std::string> include_dirs;
 	std::vector<DWARF_FileName> files;
 
 	unsigned long address;
@@ -362,7 +362,7 @@ struct DWARF_LineState
 	unsigned int  discriminator;
 
 	// not part of the "documented" state
-	DWARF_FileName* file_ptr;
+	DWARF_FileName cur_file;
 	unsigned long seg_offset;
 	unsigned long section;
 	unsigned long last_addr;
@@ -371,7 +371,6 @@ struct DWARF_LineState
 
 	DWARF_LineState()
 	{
-		file_ptr = nullptr;
 		seg_offset = 0x400000;
 		last_addr = 0;
 		lineInfo_file = 0;


### PR DESCRIPTION
This PR implements enough dwarf5 support to produce PDBs for git-for-windows.

Please see the individual commits for layered changes.  I'd be happy to take another stab at re-layering if that would help drive this change to acceptance.