### PR TITLE
Fixed building with VS 2022

### DIFF
--- a/src/PEImage.h
+++ b/src/PEImage.h
@@ -10,6 +10,7 @@
 #include "LastError.h"
 
 #include <windows.h>
+#include <string>
 #include <unordered_map>
 
 struct OMFDirHeader;


### PR DESCRIPTION
`unordered_map` no longer includes `string`