### PR TITLE
Vastly Improved DWARF to PDB Support

### DIFF
--- a/src/NatvisFile.natvis
+++ b/src/NatvisFile.natvis
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+	<Type Name="DWARF_InfoData">
+		<DisplayString>tag={tag} code={code} {name,s}</DisplayString>
+		<Expand>
+			<Synthetic Name="children" Condition="children">
+				<Expand>
+					<LinkedListItems>
+						<HeadPointer>children</HeadPointer>
+						<NextPointer>next</NextPointer>
+						<ValueNode>this</ValueNode>
+					</LinkedListItems>
+				</Expand>
+			</Synthetic>
+			<Synthetic Name="siblings" Condition="next">
+				<Expand>
+					<LinkedListItems>
+						<HeadPointer>next</HeadPointer>
+						<NextPointer>next</NextPointer>
+						<ValueNode>this</ValueNode>
+					</LinkedListItems>
+				</Expand>
+			</Synthetic>
+		</Expand>
+	</Type>
+</AutoVisualizer>

--- a/src/PEImage.cpp
+++ b/src/PEImage.cpp
@@ -375,6 +375,7 @@ bool PEImage::_initFromCVDebugDir(IMAGE_DEBUG_DIRECTORY* ddir)
 }
 
 ///////////////////////////////////////////////////////////////////////
+// Used for PE (EXE/DLL) files.
 bool PEImage::initDWARFPtr(bool initDbgDir)
 {
 	dos = DPV<IMAGE_DOS_HEADER> (0);
@@ -410,6 +411,7 @@ bool PEImage::initDWARFPtr(bool initDbgDir)
 	return true;
 }
 
+// Used for COFF objects.
 bool PEImage::initDWARFObject()
 {
 	IMAGE_FILE_HEADER* hdr = DPV<IMAGE_FILE_HEADER> (0);
@@ -466,8 +468,11 @@ void PEImage::initSec(PESection& peSec, int secNo) const
 	peSec.secNo = secNo;
 }
 
+// Initialize all the DWARF sections present in this PE or COFF file.
+// Common to both object and image modules.
 void PEImage::initDWARFSegments()
 {
+	// Scan all the PE sections in this image.
 	for(int s = 0; s < nsec; s++)
 	{
 		const char* name = (const char*) sec[s].Name;
@@ -477,6 +482,7 @@ void PEImage::initDWARFSegments()
 			name = strtable + off;
 		}
 
+		// Is 'name' one of the DWARF sections?
 		for (const SectionDescriptor *sec_desc : sec_descriptors) {
 			if (!strcmp(name, sec_desc->name)) {
 				PESection& peSec = this->*(sec_desc->pSec);

--- a/src/PEImage.h
+++ b/src/PEImage.h
@@ -178,11 +178,16 @@ private:
 
     template<typename SYM> const char* t_findSectionSymbolName(int s) const;
 
+	// File handle to PE image.
 	int fd;
+
+	// Pointer to in-memory buffer containing loaded PE image.
 	void* dump_base;
+
+	// Size of `dump_base` in bytes.
 	int dump_total_len;
 
-	// codeview
+	// codeview fields
 	IMAGE_DOS_HEADER *dos;
 	IMAGE_NT_HEADERS32* hdr32;
 	IMAGE_NT_HEADERS64* hdr64;
@@ -200,7 +205,8 @@ private:
 	std::unordered_map<std::string, SymbolInfo> symbolCache;
 
 public:
-	//dwarf
+	// dwarf fields
+	// List of DWARF section descriptors.
 #define EXPANDSEC(name) PESection name;
 	SECTION_LIST()
 #undef EXPANDSEC

--- a/src/cv2pdb.cpp
+++ b/src/cv2pdb.cpp
@@ -897,6 +897,7 @@ void CV2PDB::checkGlobalTypeAlloc(int size, int add)
 	}
 }
 
+// Get the CodeView type descriptor for the given type ID.
 // CV-only. Returns NULL for DWARF-based images.
 const codeview_type* CV2PDB::getTypeData(int type)
 {
@@ -913,6 +914,7 @@ const codeview_type* CV2PDB::getTypeData(int type)
 	return (codeview_type*)(typeData + offset[type - BASE_USER_TYPE]);
 }
 
+// CV-only. Never called for DWARF.
 const codeview_type* CV2PDB::getUserTypeData(int type)
 {
 	type -= BASE_USER_TYPE + globalTypeHeader->cTypes;
@@ -2116,6 +2118,7 @@ int CV2PDB::appendTypedef(int type, const char* name, bool saveTranslation)
 	return typedefType;
 }
 
+// CV-only.
 void CV2PDB::appendTypedefs()
 {
 	if(Dversion == 0)

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -211,6 +211,7 @@ public:
 	OMFSegMapDesc* segMapDesc;
 	int* segFrame2Index;
 
+	// CV-only
 	OMFGlobalTypes* globalTypeHeader;
 
 	unsigned char* globalTypes;
@@ -236,8 +237,11 @@ public:
 	int cbDwarfTypes;
 	int allocDwarfTypes;
 
-	int nextUserType;
-	int nextDwarfType;
+	static constexpr int BASE_USER_TYPE = 0x1000;
+	static constexpr int BASE_DWARF_TYPE = 0x1000;
+
+	int nextUserType = BASE_USER_TYPE;
+	int nextDwarfType = BASE_DWARF_TYPE;
 	int objectType;
 
 	int emptyFieldListType;

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -245,10 +245,9 @@ public:
 	int allocDwarfTypes;
 
 	static constexpr int BASE_USER_TYPE = 0x1000;
-	static constexpr int BASE_DWARF_TYPE = 0x1000;
 
 	int nextUserType = BASE_USER_TYPE;
-	int nextDwarfType = BASE_DWARF_TYPE;
+	int nextDwarfType = BASE_USER_TYPE;
 	int objectType;
 
 	int emptyFieldListType;

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -169,17 +169,23 @@ public:
 	bool addDWARFLines();
 	bool addDWARFPublics();
 	bool writeDWARFImage(const TCHAR* opath);
+	DWARF_InfoData* findEntryByPtr(byte* entryPtr) const;
+
+	// Helper to just print the DWARF tree we've built for debugging purposes.
+	void dumpDwarfTree() const;
 
 	bool addDWARFSectionContrib(mspdb::Mod* mod, unsigned long pclo, unsigned long pchi);
 	bool addDWARFProc(DWARF_InfoData& id, const std::vector<RangeEntry> &ranges, DIECursor cursor);
+	void formatFullyQualifiedProcName(const DWARF_InfoData* proc, char* buf, size_t cbBuf) const;
+
 	int  addDWARFStructure(DWARF_InfoData& id, DIECursor cursor);
-	int  addDWARFFields(DWARF_InfoData& structid, DIECursor cursor, int off, int flStart);
-	int  addDWARFArray(DWARF_InfoData& arrayid, DIECursor cursor);
+	int  addDWARFFields(DWARF_InfoData& structid, DIECursor& cursor, int off, int flStart);
+	int  addDWARFArray(DWARF_InfoData& arrayid, const DIECursor& cursor);
 	int  addDWARFBasicType(const char*name, int encoding, int byte_size);
 	int  addDWARFEnum(DWARF_InfoData& enumid, DIECursor cursor);
 	int  getTypeByDWARFPtr(byte* ptr);
 	int  getDWARFTypeSize(const DIECursor& parent, byte* ptr);
-	void getDWARFArrayBounds(DWARF_InfoData& arrayid, DIECursor cursor,
+	void getDWARFArrayBounds(DIECursor cursor,
 		int& basetype, int& lowerBound, int& upperBound);
 	void getDWARFSubrangeInfo(DWARF_InfoData& subrangeid, const DIECursor& parent,
 		int& basetype, int& lowerBound, int& upperBound);
@@ -278,7 +284,14 @@ public:
 
 	// DWARF
 	int codeSegOff;
-	std::unordered_map<byte*, int> mapOffsetToType;
+
+	// Lookup table for type IDs based on the DWARF_InfoData::entryPtr
+	std::unordered_map<byte*, int> mapEntryPtrToTypeID;
+	// Lookup table for entries based on the DWARF_InfoData::entryPtr
+	std::unordered_map<byte*, DWARF_InfoData*> mapEntryPtrToEntry;
+
+	// Head of list of DWARF DIE nodes.
+	DWARF_InfoData* dwarfHead = nullptr;
 
 	// Default lower bound for the current compilation unit. This depends on
 	// the language of the current unit.

--- a/src/cv2pdb.h
+++ b/src/cv2pdb.h
@@ -176,14 +176,15 @@ public:
 
 	bool addDWARFSectionContrib(mspdb::Mod* mod, unsigned long pclo, unsigned long pchi);
 	bool addDWARFProc(DWARF_InfoData& id, const std::vector<RangeEntry> &ranges, DIECursor cursor);
-	void formatFullyQualifiedProcName(const DWARF_InfoData* proc, char* buf, size_t cbBuf) const;
+	void formatFullyQualifiedName(const DWARF_InfoData* node, char* buf, size_t cbBuf) const;
 
 	int  addDWARFStructure(DWARF_InfoData& id, DIECursor cursor);
 	int  addDWARFFields(DWARF_InfoData& structid, DIECursor& cursor, int off, int flStart);
 	int  addDWARFArray(DWARF_InfoData& arrayid, const DIECursor& cursor);
 	int  addDWARFBasicType(const char*name, int encoding, int byte_size);
 	int  addDWARFEnum(DWARF_InfoData& enumid, DIECursor cursor);
-	int  getTypeByDWARFPtr(byte* ptr);
+	int  getTypeByDWARFPtr(byte* typePtr);
+	int  findTypeIdByPtr(byte* typePtr) const;
 	int  getDWARFTypeSize(const DIECursor& parent, byte* ptr);
 	void getDWARFArrayBounds(DIECursor cursor,
 		int& basetype, int& lowerBound, int& upperBound);
@@ -282,13 +283,18 @@ public:
 
 	double Dversion;
 
-	// DWARF
+	// DWARF fields.
+
 	int codeSegOff;
 
 	// Lookup table for type IDs based on the DWARF_InfoData::entryPtr
 	std::unordered_map<byte*, int> mapEntryPtrToTypeID;
+	
 	// Lookup table for entries based on the DWARF_InfoData::entryPtr
 	std::unordered_map<byte*, DWARF_InfoData*> mapEntryPtrToEntry;
+
+	// A multimap keyed on entry name. Since this is not unique, we use a multimap.
+	std::multimap<std::string, DWARF_InfoData*> mapEntryNameToEntries;
 
 	// Head of list of DWARF DIE nodes.
 	DWARF_InfoData* dwarfHead = nullptr;

--- a/src/cv2pdb.vcxproj
+++ b/src/cv2pdb.vcxproj
@@ -30,14 +30,14 @@
     <ProjectGuid>{5E2BD27D-446A-4C99-9829-135F7C000D90}</ProjectGuid>
     <RootNamespace>cv2pdb</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-	<!-- guess the installed Windows SDK -->
+    <!-- guess the installed Windows SDK -->
     <WindowsSdkInstallFolder_10 Condition="'$(WindowsSdkInstallFolder_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@InstallationFolder)</WindowsSdkInstallFolder_10>
     <WindowsSdkInstallFolder_10 Condition="'$(WindowsSdkInstallFolder_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@InstallationFolder)</WindowsSdkInstallFolder_10>
     <WindowsTargetPlatformVersion_10 Condition="'$(WindowsTargetPlatformVersion_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</WindowsTargetPlatformVersion_10>
     <WindowsTargetPlatformVersion_10 Condition="'$(WindowsTargetPlatformVersion_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</WindowsTargetPlatformVersion_10>
     <!-- Sometimes the version in the registry has to .0 suffix, and sometimes it doesn't. Check and add it -->
     <WindowsTargetPlatformVersion_10 Condition="'$(WindowsTargetPlatformVersion_10)' != '' and !$(WindowsTargetPlatformVersion_10.EndsWith('.0'))">$(WindowsTargetPlatformVersion_10).0</WindowsTargetPlatformVersion_10>
-	<WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion_10)' != ''">$(WindowsTargetPlatformVersion_10)</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion_10)' != ''">$(WindowsTargetPlatformVersion_10)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -298,6 +298,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="NatvisFile.natvis" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/cv2pdb.vcxproj.filters
+++ b/src/cv2pdb.vcxproj.filters
@@ -78,4 +78,10 @@
       <Filter>Source Files</Filter>
     </MASM>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="NatvisFile.natvis" />
+  </ItemGroup>
 </Project>

--- a/src/dumplines.vcxproj
+++ b/src/dumplines.vcxproj
@@ -26,13 +26,13 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/src/dviewhelper/dviewhelper.vcxproj
+++ b/src/dviewhelper/dviewhelper.vcxproj
@@ -13,24 +13,24 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{E4424774-A7A0-4502-8626-2723904D70EA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-	<!-- guess the installed Windows SDK -->
+    <!-- guess the installed Windows SDK -->
     <WindowsSdkInstallFolder_10 Condition="'$(WindowsSdkInstallFolder_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@InstallationFolder)</WindowsSdkInstallFolder_10>
     <WindowsSdkInstallFolder_10 Condition="'$(WindowsSdkInstallFolder_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@InstallationFolder)</WindowsSdkInstallFolder_10>
     <WindowsTargetPlatformVersion_10 Condition="'$(WindowsTargetPlatformVersion_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</WindowsTargetPlatformVersion_10>
     <WindowsTargetPlatformVersion_10 Condition="'$(WindowsTargetPlatformVersion_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</WindowsTargetPlatformVersion_10>
     <!-- Sometimes the version in the registry has to .0 suffix, and sometimes it doesn't. Check and add it -->
     <WindowsTargetPlatformVersion_10 Condition="'$(WindowsTargetPlatformVersion_10)' != '' and !$(WindowsTargetPlatformVersion_10.EndsWith('.0'))">$(WindowsTargetPlatformVersion_10).0</WindowsTargetPlatformVersion_10>
-	<WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion_10)' != ''">$(WindowsTargetPlatformVersion_10)</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion_10)' != ''">10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/src/dviewhelper/dviewhelper.vcxproj
+++ b/src/dviewhelper/dviewhelper.vcxproj
@@ -20,17 +20,17 @@
     <WindowsTargetPlatformVersion_10 Condition="'$(WindowsTargetPlatformVersion_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</WindowsTargetPlatformVersion_10>
     <!-- Sometimes the version in the registry has to .0 suffix, and sometimes it doesn't. Check and add it -->
     <WindowsTargetPlatformVersion_10 Condition="'$(WindowsTargetPlatformVersion_10)' != '' and !$(WindowsTargetPlatformVersion_10.EndsWith('.0'))">$(WindowsTargetPlatformVersion_10).0</WindowsTargetPlatformVersion_10>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion_10)' != ''">10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion_10)' != ''">$(WindowsTargetPlatformVersion_10)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -786,6 +786,56 @@ void CV2PDB::formatFullyQualifiedName(const DWARF_InfoData* node, char* buf, siz
 	}
 }
 
+void mergeSpecification(DWARF_InfoData& id, const CV2PDB& context);
+
+// Find the source of an inlined function by following its 'abstract_origin' 
+// attribute references and recursively merge it into 'id'.
+// TODO: this description isn't quite right. See section 3.3.8.1 in DWARF 4 spec.
+void mergeAbstractOrigin(DWARF_InfoData& id, const CV2PDB& context)
+{
+	DWARF_InfoData* abstractOrigin = context.findEntryByPtr(id.abstract_origin);
+	if (!abstractOrigin) {
+		// Could not find abstract origin. Why not?
+		assert(false);
+		return;
+	}
+
+	// assert seems invalid, combination DW_TAG_member and DW_TAG_variable found
+	// in the wild.
+	//
+	// assert(id.tag == idspec.tag);
+
+	if (abstractOrigin->abstract_origin)
+		mergeAbstractOrigin(*abstractOrigin, context);
+	if (abstractOrigin->specification)
+		mergeSpecification(*abstractOrigin, context);
+	id.merge(*abstractOrigin);
+}
+
+// Find the declaration entry for a definition by following its 'specification'
+// attribute references and merge it into 'id'.
+void mergeSpecification(DWARF_InfoData& id, const CV2PDB& context)
+{
+	DWARF_InfoData* idspec = context.findEntryByPtr(id.specification);
+	if (!idspec) {
+		// Could not find decl for this definition. Why not?
+		assert(false);
+		return;
+	}
+
+	// assert seems invalid, combination DW_TAG_member and DW_TAG_variable found
+	// in the wild.
+	//
+	// assert(id.tag == idspec.tag);
+
+	if (idspec->abstract_origin)
+		mergeAbstractOrigin(*idspec, context);
+	if (idspec->specification) {
+		mergeSpecification(*idspec, context);
+	}
+	id.merge(*idspec);
+}
+
 bool CV2PDB::addDWARFProc(DWARF_InfoData& procid, const std::vector<RangeEntry> &ranges, DIECursor cursor)
 {
 	unsigned int pclo = ranges.front().pclo - codeSegOff;

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -2143,7 +2143,7 @@ bool CV2PDB::addDWARFPublics()
 	mspdb::Mod* mod = globalMod();
 
 	int type = 0;
-	int rc = mod->AddPublic2("public_all", img.text.secNo + 1, 0, BASE_DWARF_TYPE);
+	int rc = mod->AddPublic2("public_all", img.text.secNo + 1, 0, BASE_USER_TYPE);
 	if (rc <= 0)
 		return setError("cannot add public");
 	return true;

--- a/src/dwarf2pdb.cpp
+++ b/src/dwarf2pdb.cpp
@@ -1772,7 +1772,7 @@ bool CV2PDB::addDWARFPublics()
 	mspdb::Mod* mod = globalMod();
 
 	int type = 0;
-	int rc = mod->AddPublic2("public_all", img.text.secNo + 1, 0, 0x1000);
+	int rc = mod->AddPublic2("public_all", img.text.secNo + 1, 0, BASE_DWARF_TYPE);
 	if (rc <= 0)
 		return setError("cannot add public");
 	return true;

--- a/src/readDwarf.cpp
+++ b/src/readDwarf.cpp
@@ -766,7 +766,7 @@ DWARF_InfoData* DIECursor::readNext(DWARF_InfoData* entry, bool stopAtNull)
 			return nullptr; // root of the tree does not have a null terminator, but we know the length
 
 		id.entryPtr = ptr;
-		entryOff = img->debug_info.sectOff(ptr);
+		entryOff = id.entryOff = img->debug_info.sectOff(ptr);
 		id.code = LEB128(ptr);
 
 		// If the previously scanned node claimed to have a child, this must be a valid DIE.

--- a/src/readDwarf.cpp
+++ b/src/readDwarf.cpp
@@ -1,14 +1,12 @@
 #include "readDwarf.h"
 #include <assert.h>
 #include <array>
+#include <memory> // unique_ptr
 
 #include "PEImage.h"
+#include "cv2pdb.h"
 #include "dwarf.h"
 #include "mspdb.h"
-extern "C" {
-	#include "mscvpdb.h"
-}
-
 
 // declare hasher for pair<T1,T2>
 namespace std
@@ -365,32 +363,52 @@ Location decodeLocation(const DWARF_Attribute& attr, const Location* frameBase, 
 	return stack[0];
 }
 
-void mergeAbstractOrigin(DWARF_InfoData& id, const DIECursor& parent)
+// Find the source of an inlined function by following its 'abstract_origin' 
+// attribute references and recursively merge it into 'id'.
+// TODO: this description isn't quite right. See section 3.3.8.1 in DWARF 4 spec.
+void mergeAbstractOrigin(DWARF_InfoData& id, const CV2PDB& context)
 {
-	DIECursor specCursor(parent, id.abstract_origin);
-	DWARF_InfoData idspec;
-	specCursor.readNext(idspec);
-	// assert seems invalid, combination DW_TAG_member and DW_TAG_variable found in the wild
+	DWARF_InfoData* abstractOrigin = context.findEntryByPtr(id.abstract_origin);
+	if (!abstractOrigin) {
+		// Could not find abstract origin. Why not?
+		assert(false);
+		return;
+	}
+
+	// assert seems invalid, combination DW_TAG_member and DW_TAG_variable found
+	// in the wild.
+	//
 	// assert(id.tag == idspec.tag);
-	if (idspec.abstract_origin)
-		mergeAbstractOrigin(idspec, parent);
-	if (idspec.specification)
-		mergeSpecification(idspec, parent);
-	id.merge(idspec);
+
+	if (abstractOrigin->abstract_origin)
+		mergeAbstractOrigin(*abstractOrigin, context);
+	if (abstractOrigin->specification)
+		mergeSpecification(*abstractOrigin, context);
+	id.merge(*abstractOrigin);
 }
 
-void mergeSpecification(DWARF_InfoData& id, const DIECursor& parent)
+// Find the declaration entry for a definition by following its 'specification'
+// attribute references and merge it into 'id'.
+void mergeSpecification(DWARF_InfoData& id, const CV2PDB& context)
 {
-	DIECursor specCursor(parent, id.specification);
-	DWARF_InfoData idspec;
-	specCursor.readNext(idspec);
-	//assert seems invalid, combination DW_TAG_member and DW_TAG_variable found in the wild
-	//assert(id.tag == idspec.tag);
-	if (idspec.abstract_origin)
-		mergeAbstractOrigin(idspec, parent);
-	if (idspec.specification)
-		mergeSpecification(idspec, parent);
-	id.merge(idspec);
+	DWARF_InfoData* idspec = context.findEntryByPtr(id.specification);
+	if (!idspec) {
+		// Could not find decl for this definition. Why not?
+		assert(false);
+		return;
+	}
+
+	// assert seems invalid, combination DW_TAG_member and DW_TAG_variable found
+	// in the wild.
+	//
+	// assert(id.tag == idspec.tag);
+
+	if (idspec->abstract_origin)
+		mergeAbstractOrigin(*idspec, context);
+	if (idspec->specification) {
+		mergeSpecification(*idspec, context);
+	}
+	id.merge(*idspec);
 }
 
 LOCCursor::LOCCursor(const DIECursor& parent, unsigned long off)
@@ -584,7 +602,7 @@ DIECursor::DIECursor(DWARF_CompilationUnitInfo* cu_, byte* ptr_)
 	cu = cu_;
 	ptr = ptr_;
 	level = 0;
-	hasChild = false;
+	prevHasChild = false;
 	sibling = 0;
 }
 
@@ -594,40 +612,41 @@ DIECursor::DIECursor(const DIECursor& parent, byte* ptr_)
 	ptr = ptr_;
 }
 
+// Advance the cursor to the next sibling of the current node, using the fast
+// path when possible.
 void DIECursor::gotoSibling()
 {
 	if (sibling)
 	{
-		// use sibling pointer, if available
+		// Fast path: use sibling pointer, if available.
 		ptr = sibling;
-		hasChild = false;
+		prevHasChild = false;
 	}
-	else if (hasChild)
+	else if (prevHasChild)
 	{
-		int currLevel = level;
+		// Slow path. Skip over child nodes until we get back to the current
+		// level.
+		const int currLevel = level;
 		level = currLevel + 1;
-		hasChild = false;
+		prevHasChild = false;
 
+		// Don't store these in the tree since this is just used for skipping over
+		// last swaths of nodes.
 		DWARF_InfoData dummy;
-		// read untill we pop back to the level we were at
-		while (level > currLevel)
-			readNext(dummy, true);
-	}
-}
 
-bool DIECursor::readSibling(DWARF_InfoData& id)
-{
-    gotoSibling();
-	return readNext(id, true);
+		// read until we pop back to the level we were at
+		while (level > currLevel)
+			readNext(&dummy, true /* stopAtNull */);
+	}
 }
 
 DIECursor DIECursor::getSubtreeCursor()
 {
-	if (hasChild)
+	if (prevHasChild)
 	{
 		DIECursor subtree = *this;
 		subtree.level = 0;
-		subtree.hasChild = false;
+		subtree.prevHasChild = false;
 		return subtree;
 	}
 	else // Return invalid cursor
@@ -696,31 +715,80 @@ static byte* getPointerInSection(const PEImage &img, const SectionDescriptor &se
 	return peSec.byteAt(offset);
 }
 
-bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
+// Scan the next DIE from the current CU.
+// TODO: Allocate a new element each time.
+DWARF_InfoData* DIECursor::readNext(DWARF_InfoData* entry, bool stopAtNull)
 {
-	id.clear();
+	std::unique_ptr<DWARF_InfoData> node;
 
-	if (hasChild)
+	// Controls whether we should bother establishing links between nodes.
+	// If 'entry' is provided, we are just going to be using it instead
+	// of allocating our own nodes. The callers typically reuse the same
+	// node over and over in this case, so don't bother tracking the links.
+	// Furthermore, since we clear the input node in this case, we can't rely
+	// on it from call to call.
+	// TODO: Rethink how to more cleanly express the alloc vs reuse modes of
+	// operation.
+	bool establishLinks = false;
+
+	// If an entry was passed in, use it. Else allocate one.
+	if (!entry) {
+		establishLinks = true;
+		node = std::make_unique<DWARF_InfoData>();
+		entry = node.get();
+	} else {
+		// If an entry was provided, make sure we clear it.
+		entry->clear();
+	}
+
+	entry->img = img;
+	
+	if (prevHasChild) {
+		// Prior element had a child, thus this element is its first child.
 		++level;
 
+		if (establishLinks) {
+			// Establish the first child.
+			prevParent->children = entry;
+		}
+	}
+
+	// Set up a convenience alias.
+	DWARF_InfoData& id = *entry;
+
+	// Find the first valid DIE.
 	for (;;)
 	{
 		if (level == -1)
-			return false; // we were already at the end of the subtree
+			return nullptr; // we were already at the end of the subtree
 
 		if (ptr >= cu->end_ptr)
-			return false; // root of the tree does not have a null terminator, but we know the length
+			return nullptr; // root of the tree does not have a null terminator, but we know the length
 
 		id.entryPtr = ptr;
 		entryOff = img->debug_info.sectOff(ptr);
 		id.code = LEB128(ptr);
+
+		// If the previously scanned node claimed to have a child, this must be a valid DIE.
+		assert(!prevHasChild || id.code);
+
+		// Check if we need to terminate the sibling chain.
 		if (id.code == 0)
 		{
-			--level; // pop up one level
+			// Done with this level.
+			if (establishLinks) {
+				// Continue linking siblings from the parent node.
+				prevNode = prevParent;
+
+				// Unwind the parent one level up.
+				prevParent = prevParent->parent;
+			}
+
+			--level;
 			if (stopAtNull)
 			{
-				hasChild = false;
-				return false;
+				prevHasChild = false;
+				return nullptr;
 			}
 			continue; // read the next DIE
 		}
@@ -733,17 +801,42 @@ bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
 		fprintf(stderr, "ERROR: %s:%d: unknown abbrev: num=%d off=%x\n", __FUNCTION__, __LINE__,
 				id.code, entryOff);
 		assert(abbrev);
-		return false;
+		return nullptr;
 	}
 
 	id.abbrev = abbrev;
 	id.tag = LEB128(abbrev);
 	id.hasChild = *abbrev++;
 
+	if (establishLinks) {
+		// If there was a previous node, link it to this one, thus continuing the chain.
+		if (prevNode) {
+			prevNode->next = entry;
+		}
+
+		// Establish parent of current node. If 'prevParent' is NULL, that is fine.
+		// It just means this node is a top-level node.
+		entry->parent = prevParent;
+
+		if (id.hasChild) {
+			// This node has children! Establish it as the new parent for future nodes.		
+			prevParent = entry;
+
+			// Clear the last DIE because the next scanned node will form the *start*
+			// of a new linked list comprising the children of the current node.
+			prevNode = nullptr;
+		}
+		else {
+			// Ensure the next node appends itself to this one.
+			prevNode = entry;
+		}
+	}
+
 	if (debug & DbgDwarfAttrRead)
 		fprintf(stderr, "%s:%d: offs=%x level=%d tag=%d abbrev=%d\n", __FUNCTION__, __LINE__,
 				entryOff, level, id.tag, id.code);
 
+	// Read all the attribute data for this DIE.
 	int attr, form;
 	for (;;)
 	{
@@ -809,7 +902,7 @@ bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
 			case DW_FORM_sec_offset:     a.type = SecOffset; a.sec_offset = RDref(ptr); break;
 			case DW_FORM_loclistx:       a.type = SecOffset; a.sec_offset = resolveIndirectSecPtr(LEB128(ptr), sec_desc_debug_loclists, cu->loclist_base); break;
 			case DW_FORM_rnglistx:       a.type = SecOffset; a.sec_offset = resolveIndirectSecPtr(LEB128(ptr), sec_desc_debug_rnglists, cu->rnglist_base); break;
-			default: assert(false && "Unsupported DWARF attribute form"); return false;
+			default: assert(false && "Unsupported DWARF attribute form"); return nullptr;
 		}
 
 		switch (attr)
@@ -852,6 +945,7 @@ bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
 			case DW_AT_type:      assert(a.type == Ref); id.type = a.ref; break;
 			case DW_AT_inline:    assert(a.type == Const); id.inlined = a.cons; break;
 			case DW_AT_external:  assert(a.type == Flag); id.external = a.flag; break;
+			case DW_AT_declaration: assert(a.type == Flag); id.isDecl = a.flag; break;
 			case DW_AT_upper_bound:
 				assert(a.type == Const || a.type == Ref || a.type == ExprLoc || a.type == Block);
 				if (a.type == Const) // TODO: other types not supported yet
@@ -912,10 +1006,12 @@ bool DIECursor::readNext(DWARF_InfoData& id, bool stopAtNull)
 		}
 	}
 
-	hasChild = id.hasChild != 0;
+	prevHasChild = id.hasChild != 0;
 	sibling = id.sibling;
 
-	return true;
+	// Transfer ownership of 'node' to caller, if we allocated one.
+	node.release();
+	return entry;
 }
 
 byte* DIECursor::getDWARFAbbrev(unsigned off, unsigned findcode)

--- a/src/readDwarf.cpp
+++ b/src/readDwarf.cpp
@@ -34,6 +34,11 @@ void DIECursor::setContext(PEImage* img_, DebugLevel debug_)
 	debug = debug_;
 }
 
+// Read one compilation unit from `img`'s .debug_info section, starting at
+// offset `*off`, updating it in the process to the start of the next one in the
+// section.
+// Returns a pointer to the first DIE, skipping past the CU header, or NULL
+// on failure.
 byte* DWARF_CompilationUnitInfo::read(DebugLevel debug, const PEImage& img, unsigned long *off)
 {
 	byte* ptr = img.debug_info.byteAt(*off);

--- a/src/readDwarf.cpp
+++ b/src/readDwarf.cpp
@@ -363,54 +363,6 @@ Location decodeLocation(const DWARF_Attribute& attr, const Location* frameBase, 
 	return stack[0];
 }
 
-// Find the source of an inlined function by following its 'abstract_origin' 
-// attribute references and recursively merge it into 'id'.
-// TODO: this description isn't quite right. See section 3.3.8.1 in DWARF 4 spec.
-void mergeAbstractOrigin(DWARF_InfoData& id, const CV2PDB& context)
-{
-	DWARF_InfoData* abstractOrigin = context.findEntryByPtr(id.abstract_origin);
-	if (!abstractOrigin) {
-		// Could not find abstract origin. Why not?
-		assert(false);
-		return;
-	}
-
-	// assert seems invalid, combination DW_TAG_member and DW_TAG_variable found
-	// in the wild.
-	//
-	// assert(id.tag == idspec.tag);
-
-	if (abstractOrigin->abstract_origin)
-		mergeAbstractOrigin(*abstractOrigin, context);
-	if (abstractOrigin->specification)
-		mergeSpecification(*abstractOrigin, context);
-	id.merge(*abstractOrigin);
-}
-
-// Find the declaration entry for a definition by following its 'specification'
-// attribute references and merge it into 'id'.
-void mergeSpecification(DWARF_InfoData& id, const CV2PDB& context)
-{
-	DWARF_InfoData* idspec = context.findEntryByPtr(id.specification);
-	if (!idspec) {
-		// Could not find decl for this definition. Why not?
-		assert(false);
-		return;
-	}
-
-	// assert seems invalid, combination DW_TAG_member and DW_TAG_variable found
-	// in the wild.
-	//
-	// assert(id.tag == idspec.tag);
-
-	if (idspec->abstract_origin)
-		mergeAbstractOrigin(*idspec, context);
-	if (idspec->specification) {
-		mergeSpecification(*idspec, context);
-	}
-	id.merge(*idspec);
-}
-
 LOCCursor::LOCCursor(const DIECursor& parent, unsigned long off)
 	: parent(parent)
 {

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -547,9 +547,6 @@ typedef std::unordered_map<std::pair<unsigned, unsigned>, byte*> abbrevMap_t;
 // as either an absolute value, a register, or a register-relative address.
 Location decodeLocation(const DWARF_Attribute& attr, const Location* frameBase = 0, int at = 0);
 
-void mergeAbstractOrigin(DWARF_InfoData& id, const CV2PDB& context);
-void mergeSpecification(DWARF_InfoData& id, const CV2PDB& context);
-
 // Debug Information Entry Cursor
 class DIECursor
 {

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -470,9 +470,15 @@ struct Location
 class LOCEntry
 {
 public:
-	unsigned long beg_offset;
-	unsigned long end_offset;
+	// TODO: investigate making these 64bit (or vary). Also consider renaming
+	// to Value0 and Value1 since their meanings varies depending on entry type.
+	unsigned long beg_offset; // or -1U for base address selection entries
+	unsigned long end_offset; // or the base address in base address selection entries
+
+	// DWARF v5 only. See DW_LLE_default_location.
 	bool isDefault;
+
+	// Location description.
 	Location loc;
 
 	void addBase(uint32_t base)
@@ -482,16 +488,24 @@ public:
 	}
 };
 
-// Location list cursor
+// Location list cursor (see DWARF v4 and v5 Section 2.6).
 class LOCCursor
 {
 public:
 	LOCCursor(const DIECursor& parent, unsigned long off);
 
 	const DIECursor& parent;
+
+	// The base address for subsequent loc list entries read in a given list.
+	// Default to the CU base in the absense of any base address selection entries.
+	//
+	// TODO: So far we only assign to this but never actually use it.
 	uint32_t base;
+
 	byte* end;
 	byte* ptr;
+
+	// Is this image using the new debug_loclists section in DWARF v5?
 	bool isLocLists;
 
 	bool readNext(LOCEntry& entry);

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -191,6 +191,8 @@ struct DWARF_InfoData
 	// Pointer into the memory-mapped image section where this DIE is located.
 	byte* entryPtr;
 
+	unsigned int entryOff = 0;  // the entry offset in the section it is in.
+
 	// Code to find the abbrev entry for this DIE, or 0 if it a sentinel marking
 	// the end of a sibling chain.
 	int code;

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -180,24 +180,37 @@ struct DWARF_FileName
 	}
 };
 
+// In-memory representation of a DIE (Debugging Info Entry).
 struct DWARF_InfoData
 {
+	// Pointer into the mapped image section where this DIE is located.
 	byte* entryPtr;
+
+	// Code to find the abbrev entry for this DIE, or 0 if it a sentinel marking
+	// the end of a sibling chain.
 	int code;
+
+	// Pointer to the abbreviation table entry that corresponds to this DIE.
 	byte* abbrev;
 	int tag;
+
+	// Does this DIE have children?
 	int hasChild;
 
 	const char* name;
 	const char* linkage_name;
 	const char* dir;
 	unsigned long byte_size;
+
+	// Pointer to the sibling DIE in the mapped image.
 	byte* sibling;
 	unsigned long encoding;
 	unsigned long pclo;
 	unsigned long pchi;
 	unsigned long ranges; // -1u when attribute is not present
 	unsigned long pcentry;
+
+	// Pointer to the DW_AT_type DIE describing the type of this DIE.
 	byte* type;
 	byte* containing_type;
 	byte* specification;

--- a/src/readDwarf.h
+++ b/src/readDwarf.h
@@ -11,6 +11,7 @@
 typedef unsigned char byte;
 class PEImage;
 class DIECursor;
+class CV2PDB;
 struct SectionDescriptor;
 
 enum DebugLevel : unsigned {
@@ -24,7 +25,8 @@ enum DebugLevel : unsigned {
 	DbgDwarfAttrRead = 0x400,
 	DbgDwarfLocLists = 0x800,
 	DbgDwarfRangeLists = 0x1000,
-	DbgDwarfLines = 0x2000
+	DbgDwarfLines = 0x2000,
+	DbgPrintDwarfTree = 0x4000,
 };
 
 DEFINE_ENUM_FLAG_OPERATORS(DebugLevel);
@@ -183,7 +185,10 @@ struct DWARF_FileName
 // In-memory representation of a DIE (Debugging Info Entry).
 struct DWARF_InfoData
 {
-	// Pointer into the mapped image section where this DIE is located.
+	// The PEImage for this entry.
+	PEImage* img = nullptr;
+
+	// Pointer into the memory-mapped image section where this DIE is located.
 	byte* entryPtr;
 
 	// Code to find the abbrev entry for this DIE, or 0 if it a sentinel marking
@@ -196,6 +201,18 @@ struct DWARF_InfoData
 
 	// Does this DIE have children?
 	int hasChild;
+
+	// Parent of this DIE, or NULL if top-level element.
+	DWARF_InfoData* parent = nullptr;
+
+	// Pointer to sibling in the tree. Not to be confused with 'sibling' below,
+	// which is a raw pointer to the DIE in the mapped/loaded image section.
+	// NULL if no more elements.
+	DWARF_InfoData* next = nullptr;
+
+	// Pointer to first child. This forms a linked list with the 'next' pointer.
+	// NULL if no children.
+	DWARF_InfoData* children = nullptr;
 
 	const char* name;
 	const char* linkage_name;
@@ -213,10 +230,14 @@ struct DWARF_InfoData
 	// Pointer to the DW_AT_type DIE describing the type of this DIE.
 	byte* type;
 	byte* containing_type;
+
+	// Pointer to the DIE representing the declaration for this element if it
+	// is a definition. E.g. function decl for its definition/body.
 	byte* specification;
 	byte* abstract_origin;
 	unsigned long inlined;
-	bool external;
+	bool external = false; // is this subroutine visible outside its compilation unit?
+	bool isDecl = false; // is this a declaration?
 	DWARF_Attribute location;
 	DWARF_Attribute member_location;
 	DWARF_Attribute frame_base;
@@ -236,6 +257,7 @@ struct DWARF_InfoData
 		abbrev = 0;
 		tag = 0;
 		hasChild = 0;
+		parent = nullptr;
 
 		name = 0;
 		linkage_name = 0;
@@ -252,7 +274,8 @@ struct DWARF_InfoData
 		specification = 0;
 		abstract_origin = 0;
 		inlined = 0;
-		external = 0;
+		external = false;
+		isDecl = false;
 		member_location.type = Invalid;
 		location.type = Invalid;
 		frame_base.type = Invalid;
@@ -508,19 +531,31 @@ typedef std::unordered_map<std::pair<unsigned, unsigned>, byte*> abbrevMap_t;
 // as either an absolute value, a register, or a register-relative address.
 Location decodeLocation(const DWARF_Attribute& attr, const Location* frameBase = 0, int at = 0);
 
-void mergeAbstractOrigin(DWARF_InfoData& id, const DIECursor& parent);
-void mergeSpecification(DWARF_InfoData& id, const DIECursor& parent);
+void mergeAbstractOrigin(DWARF_InfoData& id, const CV2PDB& context);
+void mergeSpecification(DWARF_InfoData& id, const CV2PDB& context);
 
 // Debug Information Entry Cursor
 class DIECursor
 {
+	// TODO: make these private.
 public:
-	DWARF_CompilationUnitInfo* cu;
-	byte* ptr;
+	DWARF_CompilationUnitInfo* cu = nullptr; // the CU we are reading from.
+	byte* ptr = nullptr; // the current mapped location we are reading from.
 	unsigned int entryOff;
-	int level;
-	bool hasChild; // indicates whether the last read DIE has children
-	byte* sibling;
+	int level; // the current level of the tree in the scan.
+	bool prevHasChild = false; // indicates whether the last read DIE has children
+
+	// last DIE scanned. Used to link subsequent nodes in a list.
+	DWARF_InfoData* prevNode = nullptr;
+	
+	// The last parent node to which all subsequent nodes should be assigned.
+	// Initially, NULL, but as we encounter a node with children, we establish
+	// it as the new "parent" for future nodes, and reset it once we reach
+	// a top level node.
+	DWARF_InfoData* prevParent = nullptr;
+
+	// The mapped address of the sibling of the last scanned node, if any.
+	byte* sibling = nullptr;
 
 	static PEImage *img;
 	static abbrevMap_t abbrevMap;
@@ -541,17 +576,13 @@ public:
 	// Goto next sibling DIE.  If the last read DIE had any children, they will be skipped over.
 	void gotoSibling();
 
-	// Reads next sibling DIE.  If the last read DIE had any children, they will be skipped over.
-	// Returns 'false' upon reaching the last sibling on the current level.
-	bool readSibling(DWARF_InfoData& id);
-
 	// Returns cursor that will enumerate children of the last read DIE.
 	DIECursor getSubtreeCursor();
 
-	// Reads the next DIE in physical order, returns 'true' if succeeds.
+	// Reads the next DIE in physical order, returns non-NULL if succeeds.
 	// If stopAtNull is true, readNext() will stop upon reaching a null DIE (end of the current tree level).
 	// Otherwise, it will skip null DIEs and stop only at the end of the subtree for which this DIECursor was created.
-	bool readNext(DWARF_InfoData& id, bool stopAtNull = false);
+	DWARF_InfoData* readNext(DWARF_InfoData* entry, bool stopAtNull = false);
 
 	// Read an address from p according to the ambient pointer size.
 	uint64_t RDAddr(byte* &p) const


### PR DESCRIPTION
This PR contributes a number of significant improvements to DWARF to PDB conversion. The key one being construction of a "DWARF tree" to allow for fully-qualified name generation for procs, structs, enums and classes. The individual commits have detailed descriptions of what each one does.

This was tested on a sizable cross-compiled binary (via clang + mingw) from [AOSP](https://source.android.com/) (`aidl.exe` in particular) and is what motivated these improvements. Prior to this PR, one was not able to get usable symbols after conversion. For example, classes were not able to be inspected and showed up as empty, among other things.

NOTE: Only DWARF v4 was tested. DWARF v5 seems like a work in progress anyway and incomplete based on my attempts at converting the DWARF v5-compiled `aidl.exe`.